### PR TITLE
Fix block workload precision

### DIFF
--- a/lib/screens/block_summary.dart
+++ b/lib/screens/block_summary.dart
@@ -17,7 +17,7 @@ class _BlockSummaryScreenState extends State<BlockSummaryScreen> {
   final UserStatsService _statsService = UserStatsService();
 
   String blockName = '';
-  int blockWorkload = 0;
+  double blockWorkload = 0.0;
   int workoutsCompleted = 0;
   int daysTaken = 0;
   int totalCalendarDays = 0;
@@ -100,7 +100,7 @@ class _BlockSummaryScreenState extends State<BlockSummaryScreen> {
               style: TextStyle(fontSize: 20, color: Colors.grey),
             ),
             const SizedBox(height: 30),
-            Text('Block Workload: $blockWorkload lbs'),
+            Text('Block Workload: ${blockWorkload.toStringAsFixed(1)} lbs'),
             Text('Workouts Completed: $workoutsCompleted'),
             Text('Days Taken: $daysTaken'),
             if (feedbackMessage.isNotEmpty)

--- a/lib/services/user_stats_service.dart
+++ b/lib/services/user_stats_service.dart
@@ -1,4 +1,4 @@
-import 'db_service.dart'; // or wherever your main DB access is
+import 'db_service.dart';
 
 
 
@@ -17,7 +17,7 @@ class UserStatsService {
     return result.isNotEmpty ? result.first['blockName'] as String : 'Block';
   }
 
-  Future<int> getBlockWorkload(int blockInstanceId) async {
+  Future<double> getBlockWorkload(int blockInstanceId) async {
     final db = await _dbService.database;
     final result = await db.rawQuery('''
       SELECT SUM(workoutWorkload) as totalWorkload
@@ -26,7 +26,7 @@ class UserStatsService {
       WHERE wi.blockInstanceId = ?
     ''', [blockInstanceId]);
 
-    return (result.first['totalWorkload'] as int?) ?? 0;
+    return (result.first['totalWorkload'] as num?)?.toDouble() ?? 0.0;
   }
 
   Future<int> getCompletedWorkoutCount(int blockInstanceId) async {


### PR DESCRIPTION
## Summary
- return workout workload totals as double
- show workload with one decimal place in summary screen
- clean up stray comment in UserStatsService

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f3b1c62248323ab50e604a1933c92