### PR TITLE
Improve badge display UI

### DIFF
--- a/lib/widgets/badge_display.dart
+++ b/lib/widgets/badge_display.dart
@@ -1,50 +1,177 @@
-import 'package:flutter/material.dart';
+import 'dart:math';
+
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import '../services/user_stats_service.dart';
+import '../services/pr_service.dart';
 
 class BadgeDisplay extends StatelessWidget {
   final String userId;
 
   const BadgeDisplay({super.key, required this.userId});
 
-  Future<List<Map<String, dynamic>>> _fetchBadges() async {
-    final snapshot = await FirebaseFirestore.instance
+  /// Catalog of all available badge types
+  List<Map<String, String>> get _badgeCatalog => [
+        {
+          'name': 'Meat Wagon',
+          'icon': 'assets/images/badges/meatWagonIcon_01.png',
+          'description': 'Every 100k lbs moved'
+        },
+        {
+          'name': 'Lunch Lady',
+          'icon': 'assets/images/badges/lunchLadyIcon_01.png',
+          'description': 'Hit big PR milestones'
+        },
+        {
+          'name': 'Punch Card',
+          'icon': 'assets/images/badges/punchCard_01.png',
+          'description': '8 weeks of 3+ workouts'
+        },
+        {
+          'name': 'Hype Man',
+          'icon': 'assets/images/badges/hypeMan.png',
+          'description': 'Like 100 check-ins'
+        },
+        {
+          'name': 'Daily Driver',
+          'icon': 'assets/images/badges/dailyDriver.png',
+          'description': 'Most workouts in circle'
+        },
+      ];
+
+  // Helper to compute ISO week string (yyyy-Wweek)
+  String _isoWeekKey(DateTime date) {
+    final weekYear = DateFormat('yyyy').format(date);
+    final weekOfYear =
+        ((date.difference(DateTime(date.year, 1, 1)).inDays +
+                    DateTime(date.year, 1, 1).weekday -
+                    1) ~/
+                7) +
+            1;
+    return '$weekYear-W$weekOfYear';
+  }
+
+  Future<Map<String, dynamic>> _fetchData() async {
+    final firestore = FirebaseFirestore.instance;
+
+    // Badge counts
+    final badgeSnap = await firestore
         .collection('users')
         .doc(userId)
         .collection('badges')
-        .orderBy('unlockDate', descending: true)
         .get();
+    final Map<String, int> counts = {};
+    for (var doc in badgeSnap.docs) {
+      final name = doc['name'] ?? '';
+      counts[name] = (counts[name] ?? 0) + 1;
+    }
 
-    final badgeCounts = <String, Map<String, dynamic>>{};
+    // Stats used for progress calculations
+    final totalLbs = await UserStatsService().getTotalLbsLifted(userId);
+    final userDoc = await firestore.collection('users').doc(userId).get();
+    final likesGiven = (userDoc.data()?['likesGiven'] ?? 0) as int;
+    final prs = await getBig3PRs(userId);
+    double maxPr = 0;
+    for (final w in prs.values) {
+      maxPr = max(maxPr, w);
+    }
 
-    for (var doc in snapshot.docs) {
-      final data = doc.data();
-      final name = data['name'] ?? 'Unnamed Badge';
-      if (badgeCounts.containsKey(name)) {
-        badgeCounts[name]!['count'] += 1;
+    // Punch card streak
+    final now = DateTime.now();
+    final eightWeeksAgo = now.subtract(const Duration(days: 56));
+    final workoutsSnap = await firestore
+        .collection('users')
+        .doc(userId)
+        .collection('workouts')
+        .where('completed', isEqualTo: true)
+        .where('timestamp', isGreaterThan: Timestamp.fromDate(eightWeeksAgo))
+        .get();
+    final Map<String, int> weeklyCounts = {};
+    for (var doc in workoutsSnap.docs) {
+      final ts = (doc['timestamp'] as Timestamp).toDate();
+      final isoWeek = _isoWeekKey(ts);
+      weeklyCounts[isoWeek] = (weeklyCounts[isoWeek] ?? 0) + 1;
+    }
+    final sortedWeeks = weeklyCounts.keys.toList()..sort();
+    int streak = 0;
+    for (final week in sortedWeeks.reversed) {
+      if (weeklyCounts[week]! >= 3) {
+        streak++;
+        if (streak == 8) break;
       } else {
-        badgeCounts[name] = {
-          ...data,
-          'count': 1,
-        };
+        break;
       }
     }
 
-    return badgeCounts.values.toList();
-  }
+    // Workouts logged this month (for Daily Driver progress)
+    final startOfMonth = DateTime(now.year, now.month, 1);
+    final monthSnap = await firestore
+        .collection('users')
+        .doc(userId)
+        .collection('workouts')
+        .where('completed', isEqualTo: true)
+        .where('timestamp', isGreaterThanOrEqualTo: Timestamp.fromDate(startOfMonth))
+        .get();
+    final monthWorkouts = monthSnap.docs.length;
 
+    return {
+      'counts': counts,
+      'totalLbs': totalLbs,
+      'likesGiven': likesGiven,
+      'maxPr': maxPr,
+      'streak': streak,
+      'monthWorkouts': monthWorkouts,
+    };
+  }
 
   @override
   Widget build(BuildContext context) {
-    return FutureBuilder<List<Map<String, dynamic>>>(
-      future: _fetchBadges(),
+    return FutureBuilder<Map<String, dynamic>>(
+      future: _fetchData(),
       builder: (context, snapshot) {
         if (!snapshot.hasData) {
           return const Center(child: CircularProgressIndicator());
         }
 
-        final badges = snapshot.data!;
-        if (badges.isEmpty) {
-          return const Text('No badges earned yet.', style: TextStyle(color: Colors.white));
+        final data = snapshot.data!;
+        final counts = Map<String, int>.from(data['counts'] as Map);
+        final totalLbs = data['totalLbs'] as double;
+        final likesGiven = data['likesGiven'] as int;
+        final maxPr = data['maxPr'] as double;
+        final streak = data['streak'] as int;
+        final monthWorkouts = data['monthWorkouts'] as int;
+
+        // Build display list with progress values
+        final List<Map<String, dynamic>> badges = [];
+        for (final def in _badgeCatalog) {
+          final name = def['name']!;
+          final count = counts[name] ?? 0;
+          double progress = 0.0;
+          switch (name) {
+            case 'Meat Wagon':
+              progress = ((totalLbs % 100000) / 100000).clamp(0.0, 1.0);
+              break;
+            case 'Lunch Lady':
+              progress = (maxPr / 405).clamp(0.0, 1.0);
+              break;
+            case 'Punch Card':
+              progress = (streak / 8).clamp(0.0, 1.0);
+              break;
+            case 'Hype Man':
+              progress = ((likesGiven % 100) / 100).clamp(0.0, 1.0);
+              break;
+            case 'Daily Driver':
+              progress = (monthWorkouts / 12).clamp(0.0, 1.0);
+              break;
+          }
+          badges.add({
+            'name': name,
+            'description': def['description'],
+            'icon': def['icon'],
+            'count': count,
+            'progress': progress,
+          });
         }
 
         return Column(
@@ -52,7 +179,8 @@ class BadgeDisplay extends StatelessWidget {
           children: [
             const Text(
               'Badges',
-              style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold, color: Colors.white),
+              style: TextStyle(
+                  fontSize: 20, fontWeight: FontWeight.bold, color: Colors.white),
             ),
             const SizedBox(height: 10),
             ListView.builder(
@@ -61,91 +189,57 @@ class BadgeDisplay extends StatelessWidget {
               itemCount: badges.length,
               itemBuilder: (context, index) {
                 final badge = badges[index];
-                final String imagePath = badge['imagePath'] ?? 'assets/images/badges/meatWagon_01.png';
-                final String title = badge['name'] ?? '';
-                final String description = badge['description'] ?? '';
-                final int count = badge['count'] ?? 1;
-
+                final bool earned = badge['count'] > 0;
                 return Padding(
                   padding: const EdgeInsets.symmetric(vertical: 6),
                   child: Row(
-                    crossAxisAlignment: CrossAxisAlignment.center,
+                    crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      // 🖼️ Clickable Badge Image
-                      GestureDetector(
-                        onTap: () {
-                          showDialog(
-                            context: context,
-                            builder: (_) => Dialog(
-                              backgroundColor: Colors.transparent,
-                              insetPadding: const EdgeInsets.all(20),
-                              child: Column(
-                                mainAxisSize: MainAxisSize.min,
-                                children: [
-                                  Image.asset(
-                                    imagePath,
-                                    fit: BoxFit.contain,
-                                    errorBuilder: (_, __, ___) =>
-                                    const Icon(Icons.broken_image, size: 64),
-                                  ),
-                                  const SizedBox(height: 12),
-                                  Text(
-                                    title,
-                                    style: const TextStyle(
-                                      fontSize: 18,
-                                      fontWeight: FontWeight.bold,
-                                      color: Colors.white,
-                                      decoration: TextDecoration.none,
-                                    ),
-                                    textAlign: TextAlign.center,
-                                  ),
-                                  if (description.isNotEmpty)
-                                    Padding(
-                                      padding: const EdgeInsets.only(top: 8),
-                                      child: Text(
-                                        description,
-                                        style: const TextStyle(
-                                          fontSize: 14,
-                                          color: Colors.white70,
-                                          decoration: TextDecoration.none,
-                                        ),
-                                        textAlign: TextAlign.center,
-                                      ),
-                                    ),
-                                ],
-                              ),
-                            ),
-                          );
-                        },
-                        child: ClipRRect(
-                          borderRadius: BorderRadius.circular(6),
-                          child: Image.asset(
-                            imagePath,
-                            height: 100,
-                            fit: BoxFit.fitHeight,
-                            errorBuilder: (_, __, ___) =>
-                            const Icon(Icons.error, size: 40),
-                          ),
+                      Opacity(
+                        opacity: earned ? 1.0 : 0.5,
+                        child: Image.asset(
+                          badge['icon'],
+                          height: 60,
+                          fit: BoxFit.fitHeight,
+                          errorBuilder: (_, __, ___) =>
+                              const Icon(Icons.error, size: 40),
                         ),
                       ),
                       const SizedBox(width: 12),
-
-                      // 🏷️ Badge title and count inline
                       Expanded(
-                        child: Text(
-                          '$title  x$count',
-                          style: const TextStyle(
-                            fontSize: 16,
-                            fontWeight: FontWeight.bold,
-                            color: Colors.white,
-                            decoration: TextDecoration.none,
-                          ),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              '${badge['name']}  x${badge['count']}',
+                              style: const TextStyle(
+                                fontSize: 16,
+                                fontWeight: FontWeight.bold,
+                                color: Colors.white,
+                                decoration: TextDecoration.none,
+                              ),
+                            ),
+                            const SizedBox(height: 4),
+                            Text(
+                              badge['description'],
+                              style: const TextStyle(
+                                fontSize: 14,
+                                color: Colors.white70,
+                                decoration: TextDecoration.none,
+                              ),
+                            ),
+                            const SizedBox(height: 6),
+                            LinearProgressIndicator(
+                              value: badge['progress'],
+                              minHeight: 6,
+                              backgroundColor: Colors.white24,
+                              color: Colors.blue,
+                            ),
+                          ],
                         ),
                       ),
                     ],
                   ),
-
-
                 );
               },
             ),


### PR DESCRIPTION
## Summary
- revamp `BadgeDisplay` widget
- show available badges even if not earned
- add badge descriptions and progress meters
- grey out only the badge image when unearned

## Testing
- `flutter format lib/widgets/badge_display.dart` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68470525f2708323ac98ebd569c50309