### PR TITLE
Implement repeating custom block

### DIFF
--- a/lib/models/custom_block_models.dart
+++ b/lib/models/custom_block_models.dart
@@ -17,8 +17,14 @@ class CustomBlock {
 class WorkoutDraft {
   int id;
   int dayIndex;
+  String name;
   List<LiftDraft> lifts;
-  WorkoutDraft({required this.id, required this.dayIndex, required this.lifts});
+  WorkoutDraft({
+    required this.id,
+    required this.dayIndex,
+    required this.name,
+    required this.lifts,
+  });
 }
 
 class LiftDraft {

--- a/lib/screens/custom_block_wizard.dart
+++ b/lib/screens/custom_block_wizard.dart
@@ -18,7 +18,6 @@ class _CustomBlockWizardState extends State<CustomBlockWizard> {
   late List<WorkoutDraft> workouts;
   int _currentStep = 0;
   int _workoutIndex = 0;
-  late CustomBlock _block;
 
   @override
   void initState() {
@@ -27,22 +26,46 @@ class _CustomBlockWizardState extends State<CustomBlockWizard> {
   }
 
   void _createDrafts() {
-    final total = (numWeeks ?? 0) * (daysPerWeek ?? 0);
+    final count = daysPerWeek ?? 0;
     workouts = List.generate(
-      total,
-          (i) => WorkoutDraft(id: i, dayIndex: i, lifts: []),
-    );
-    _block = CustomBlock(
-      id: DateTime.now().millisecondsSinceEpoch,
-      name: blockName,
-      numWeeks: numWeeks!,
-      daysPerWeek: daysPerWeek!,
-      workouts: workouts,
+      count,
+      (i) => WorkoutDraft(id: i, dayIndex: i, name: '', lifts: []),
     );
   }
 
   Future<void> _finish() async {
-    await DBService().insertCustomBlock(_block);
+    final List<WorkoutDraft> allWorkouts = [];
+    int idCounter = 0;
+    for (var week = 0; week < (numWeeks ?? 0); week++) {
+      for (var day = 0; day < workouts.length; day++) {
+        final base = workouts[day];
+        final copiedLifts = base.lifts
+            .map((l) => LiftDraft(
+                  name: l.name,
+                  sets: l.sets,
+                  repsPerSet: l.repsPerSet,
+                  multiplier: l.multiplier,
+                  isBodyweight: l.isBodyweight,
+                ))
+            .toList();
+        allWorkouts.add(WorkoutDraft(
+          id: idCounter++,
+          dayIndex: week * workouts.length + day,
+          name: base.name,
+          lifts: copiedLifts,
+        ));
+      }
+    }
+
+    final block = CustomBlock(
+      id: DateTime.now().millisecondsSinceEpoch,
+      name: blockName,
+      numWeeks: numWeeks!,
+      daysPerWeek: daysPerWeek!,
+      workouts: allWorkouts,
+    );
+
+    await DBService().insertCustomBlock(block);
     if (mounted) Navigator.pop(context);
   }
 
@@ -132,18 +155,19 @@ class _CustomBlockWizardState extends State<CustomBlockWizard> {
             content: workouts.isEmpty
                 ? const SizedBox.shrink()
                 : SizedBox(
-              height: 400,
-              child: WorkoutBuilder(
-                workout: workouts[_workoutIndex],
-                onComplete: () async {
-                  if (_workoutIndex < workouts.length - 1) {
-                    setState(() => _workoutIndex++);
-                  } else {
-                    await _finish();
-                  }
-                },
-              ),
-            ),
+                    height: 400,
+                    child: WorkoutBuilder(
+                      workout: workouts[_workoutIndex],
+                      isLast: _workoutIndex == workouts.length - 1,
+                      onComplete: () async {
+                        if (_workoutIndex < workouts.length - 1) {
+                          setState(() => _workoutIndex++);
+                        } else {
+                          await _finish();
+                        }
+                      },
+                    ),
+                  ),
             isActive: _currentStep >= 3,
           ),
         ],

--- a/lib/screens/workout_builder.dart
+++ b/lib/screens/workout_builder.dart
@@ -6,13 +6,32 @@ import 'package:lift_league/services/score_multiplier_service.dart';
 class WorkoutBuilder extends StatefulWidget {
   final WorkoutDraft workout;
   final VoidCallback onComplete;
-  const WorkoutBuilder({super.key, required this.workout, required this.onComplete});
+  final bool isLast;
+  const WorkoutBuilder({
+    super.key,
+    required this.workout,
+    required this.onComplete,
+    this.isLast = false,
+  });
 
   @override
   State<WorkoutBuilder> createState() => _WorkoutBuilderState();
 }
 
 class _WorkoutBuilderState extends State<WorkoutBuilder> {
+  late TextEditingController _nameController;
+
+  @override
+  void initState() {
+    super.initState();
+    _nameController = TextEditingController(text: widget.workout.name);
+  }
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    super.dispose();
+  }
   void _showAddLiftSheet() {
     final nameController = TextEditingController();
     int sets = 3;
@@ -101,13 +120,21 @@ class _WorkoutBuilderState extends State<WorkoutBuilder> {
   Widget build(BuildContext context) {
     return Column(
       children: [
+        Padding(
+          padding: const EdgeInsets.all(8.0),
+          child: TextField(
+            controller: _nameController,
+            decoration: const InputDecoration(labelText: 'Workout name'),
+            onChanged: (v) => widget.workout.name = v,
+          ),
+        ),
         Expanded(
           child: ListView.builder(
             itemCount: widget.workout.lifts.length,
             itemBuilder: (context, index) {
               final lift = widget.workout.lifts[index];
               return ListTile(
-                title: Text(lift.name),
+                title: Text('Lift ${index + 1}: ${lift.name}'),
                 subtitle: Text('${lift.sets} x ${lift.repsPerSet}'),
                 trailing: Text(lift.multiplier.toStringAsFixed(3)),
               );
@@ -116,7 +143,7 @@ class _WorkoutBuilderState extends State<WorkoutBuilder> {
         ),
         ElevatedButton(
           onPressed: widget.onComplete,
-          child: const Text('Next Workout'),
+          child: Text(widget.isLast ? 'Build Block' : 'Next Workout'),
         ),
         const SizedBox(height: 8),
         FloatingActionButton(

--- a/lib/services/db_service.dart
+++ b/lib/services/db_service.dart
@@ -33,7 +33,7 @@ class DBService {
 
     return await openDatabase(
       path,
-      version: 10,
+      version: 11,
       onCreate: (db, version) async {
         await db.execute("PRAGMA foreign_keys = ON;");
 
@@ -74,6 +74,9 @@ class DBService {
               FOREIGN KEY (workoutId) REFERENCES workout_drafts(id) ON DELETE CASCADE
             )
           ''');
+        }
+        if (oldVersion < 11) {
+          await db.execute("ALTER TABLE workout_drafts ADD COLUMN name TEXT;");
         }
       },
     );
@@ -232,6 +235,7 @@ class DBService {
         id INTEGER PRIMARY KEY AUTOINCREMENT,
         blockId INTEGER,
         dayIndex INTEGER,
+        name TEXT,
         FOREIGN KEY (blockId) REFERENCES custom_blocks(id) ON DELETE CASCADE
       )
     ''');
@@ -683,6 +687,7 @@ class DBService {
     final workoutId = await db.insert('workout_drafts', {
       'blockId': blockId,
       'dayIndex': w.dayIndex,
+      'name': w.name,
     });
     for (final lift in w.lifts) {
       await db.insert('lift_drafts', {


### PR DESCRIPTION
## Summary
- extend `WorkoutDraft` with a `name` field
- bump DB version and store workout names
- allow naming workouts and numbering lifts
- generate workouts for one week and repeat them for all weeks

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847969beaf0832387c94de93d9c6885