### PR TITLE
Implement repeating custom block

### DIFF
--- a/lib/models/custom_block_models.dart
+++ b/lib/models/custom_block_models.dart
@@ -3,6 +3,7 @@ class CustomBlock {
   final String name;
   final int numWeeks;
   final int daysPerWeek;
+  final bool isDraft;
   final List<WorkoutDraft> workouts;
 
   CustomBlock({
@@ -11,14 +12,21 @@ class CustomBlock {
     required this.numWeeks,
     required this.daysPerWeek,
     required this.workouts,
+    this.isDraft = false,
   });
 }
 
 class WorkoutDraft {
   int id;
   int dayIndex;
+  String name;
   List<LiftDraft> lifts;
-  WorkoutDraft({required this.id, required this.dayIndex, required this.lifts});
+  WorkoutDraft({
+    required this.id,
+    required this.dayIndex,
+    required this.name,
+    required this.lifts,
+  });
 }
 
 class LiftDraft {

--- a/lib/screens/workout_builder.dart
+++ b/lib/screens/workout_builder.dart
@@ -6,13 +6,32 @@ import 'package:lift_league/services/score_multiplier_service.dart';
 class WorkoutBuilder extends StatefulWidget {
   final WorkoutDraft workout;
   final VoidCallback onComplete;
-  const WorkoutBuilder({super.key, required this.workout, required this.onComplete});
+  final bool isLast;
+  const WorkoutBuilder({
+    super.key,
+    required this.workout,
+    required this.onComplete,
+    this.isLast = false,
+  });
 
   @override
   State<WorkoutBuilder> createState() => _WorkoutBuilderState();
 }
 
 class _WorkoutBuilderState extends State<WorkoutBuilder> {
+  late TextEditingController _nameController;
+
+  @override
+  void initState() {
+    super.initState();
+    _nameController = TextEditingController(text: widget.workout.name);
+  }
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    super.dispose();
+  }
   void _showAddLiftSheet() {
     final nameController = TextEditingController();
     int sets = 3;
@@ -101,13 +120,21 @@ class _WorkoutBuilderState extends State<WorkoutBuilder> {
   Widget build(BuildContext context) {
     return Column(
       children: [
+        Padding(
+          padding: const EdgeInsets.all(8.0),
+          child: TextField(
+            controller: _nameController,
+            decoration: const InputDecoration(labelText: 'Workout name'),
+            onChanged: (v) => widget.workout.name = v,
+          ),
+        ),
         Expanded(
           child: ListView.builder(
             itemCount: widget.workout.lifts.length,
             itemBuilder: (context, index) {
               final lift = widget.workout.lifts[index];
               return ListTile(
-                title: Text(lift.name),
+                title: Text('Lift ${index + 1}: ${lift.name}'),
                 subtitle: Text('${lift.sets} x ${lift.repsPerSet}'),
                 trailing: Text(lift.multiplier.toStringAsFixed(3)),
               );
@@ -116,7 +143,7 @@ class _WorkoutBuilderState extends State<WorkoutBuilder> {
         ),
         ElevatedButton(
           onPressed: widget.onComplete,
-          child: const Text('Next Workout'),
+          child: Text(widget.isLast ? 'Build Block' : 'Next Workout'),
         ),
         const SizedBox(height: 8),
         FloatingActionButton(

--- a/lib/widgets/block_grid_section.dart
+++ b/lib/widgets/block_grid_section.dart
@@ -9,6 +9,8 @@ class BlockGridSection extends StatelessWidget {
   final Map<String, int?> blockInstances;
   final bool isLoading;
   final Function(String, int) onNewBlockInstanceCreated;
+  final List<int>? customBlockIds;
+  final void Function(int id)? onDeleteCustomBlock;
 
   const BlockGridSection({
     super.key,
@@ -17,6 +19,8 @@ class BlockGridSection extends StatelessWidget {
     required this.blockInstances,
     required this.isLoading,
     required this.onNewBlockInstanceCreated,
+    this.customBlockIds,
+    this.onDeleteCustomBlock,
   });
 
   @override
@@ -58,6 +62,32 @@ class BlockGridSection extends StatelessWidget {
               ),
             );
           },
+          onLongPress: customBlockIds != null && onDeleteCustomBlock != null
+              ? () async {
+                  final id = customBlockIds![index];
+                  final confirm = await showDialog<bool>(
+                    context: context,
+                    builder: (ctx) => AlertDialog(
+                      title: const Text('Delete block?'),
+                      content:
+                          const Text('Are you sure you want to delete this block?'),
+                      actions: [
+                        TextButton(
+                          onPressed: () => Navigator.pop(ctx, false),
+                          child: const Text('Cancel'),
+                        ),
+                        TextButton(
+                          onPressed: () => Navigator.pop(ctx, true),
+                          child: const Text('Delete'),
+                        ),
+                      ],
+                    ),
+                  );
+                  if (confirm == true) {
+                    onDeleteCustomBlock!(id);
+                  }
+                }
+              : null,
           child: Container(
             decoration: BoxDecoration(
               image: DecorationImage(


### PR DESCRIPTION
## Summary
- extend `WorkoutDraft` with a `name` field
- bump DB version and store workout names
- allow naming workouts and numbering lifts
- generate workouts for one week and repeat them for all weeks
- let users save in-progress custom blocks as drafts
- show draft custom blocks on dashboard and allow deleting by long press

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847969beaf0832387c94de93d9c6885