### PR TITLE
Improve workout editing

### DIFF
--- a/lib/screens/user_dashboard.dart
+++ b/lib/screens/user_dashboard.dart
@@ -79,6 +79,18 @@ class _UserDashboardState extends State<UserDashboard> {
     await _fetchCustomBlocks();
   }
 
+  Future<void> _editCustomBlock(int id) async {
+    final block = await DBService().getCustomBlock(id);
+    if (block == null) return;
+    await Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => CustomBlockWizard(initialBlock: block),
+      ),
+    );
+    await _fetchCustomBlocks();
+  }
+
   Future<void> registerForPushNotifications() async {
     // Request permissions on iOS, Android 13+, etc.
     final settings = await FirebaseMessaging.instance.requestPermission(
@@ -604,6 +616,7 @@ class _UserDashboardState extends State<UserDashboard> {
                               });
                             },
                             onDeleteCustomBlock: _deleteCustomBlock,
+                            onEditCustomBlock: _editCustomBlock,
                           ),
                         ],
                         const SizedBox(height: 20),

--- a/lib/screens/workout_builder.dart
+++ b/lib/screens/workout_builder.dart
@@ -5,11 +5,17 @@ import 'package:lift_league/services/score_multiplier_service.dart';
 
 class WorkoutBuilder extends StatefulWidget {
   final WorkoutDraft workout;
+  final List<WorkoutDraft> allWorkouts;
+  final int currentIndex;
+  final ValueChanged<int> onSelectWorkout;
   final VoidCallback onComplete;
   final bool isLast;
   const WorkoutBuilder({
     super.key,
     required this.workout,
+    required this.allWorkouts,
+    required this.currentIndex,
+    required this.onSelectWorkout,
     required this.onComplete,
     this.isLast = false,
   });
@@ -136,6 +142,26 @@ class _WorkoutBuilderState extends State<WorkoutBuilder> {
             onChanged: (v) => widget.workout.name = v,
           ),
         ),
+        if (widget.allWorkouts.length > 1)
+          SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            child: Row(
+              children: List.generate(widget.allWorkouts.length, (i) {
+                final name = widget.allWorkouts[i].name.isNotEmpty
+                    ? widget.allWorkouts[i].name
+                    : 'Workout ${i + 1}';
+                final selected = i == widget.currentIndex;
+                return Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 4.0),
+                  child: ChoiceChip(
+                    label: Text(name),
+                    selected: selected,
+                    onSelected: (_) => widget.onSelectWorkout(i),
+                  ),
+                );
+              }),
+            ),
+          ),
         Expanded(
           child: ListView.builder(
             itemCount: widget.workout.lifts.length,

--- a/lib/widgets/block_grid_section.dart
+++ b/lib/widgets/block_grid_section.dart
@@ -13,6 +13,7 @@ class BlockGridSection extends StatelessWidget {
   final Function(String, int) onNewBlockInstanceCreated;
   final List<int>? customBlockIds;
   final void Function(int id)? onDeleteCustomBlock;
+  final void Function(int id)? onEditCustomBlock;
   final bool overlayNames;
 
   const BlockGridSection({
@@ -24,6 +25,7 @@ class BlockGridSection extends StatelessWidget {
     required this.onNewBlockInstanceCreated,
     this.customBlockIds,
     this.onDeleteCustomBlock,
+    this.onEditCustomBlock,
     this.overlayNames = false,
   });
 
@@ -66,32 +68,58 @@ class BlockGridSection extends StatelessWidget {
               ),
             );
           },
-          onLongPress: customBlockIds != null && onDeleteCustomBlock != null
-              ? () async {
-                  final id = customBlockIds![index];
-                  final confirm = await showDialog<bool>(
-                    context: context,
-                    builder: (ctx) => AlertDialog(
-                      title: const Text('Delete block?'),
-                      content:
-                          const Text('Are you sure you want to delete this block?'),
-                      actions: [
-                        TextButton(
-                          onPressed: () => Navigator.pop(ctx, false),
-                          child: const Text('Cancel'),
+          onLongPress:
+              customBlockIds != null && (onDeleteCustomBlock != null || onEditCustomBlock != null)
+                  ? () async {
+                      final id = customBlockIds![index];
+                      final action = await showModalBottomSheet<String>(
+                        context: context,
+                        builder: (ctx) => SafeArea(
+                          child: Column(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              if (onEditCustomBlock != null)
+                                ListTile(
+                                  leading: const Icon(Icons.edit),
+                                  title: const Text('Edit'),
+                                  onTap: () => Navigator.pop(ctx, 'edit'),
+                                ),
+                              if (onDeleteCustomBlock != null)
+                                ListTile(
+                                  leading: const Icon(Icons.delete),
+                                  title: const Text('Delete'),
+                                  onTap: () => Navigator.pop(ctx, 'delete'),
+                                ),
+                            ],
+                          ),
                         ),
-                        TextButton(
-                          onPressed: () => Navigator.pop(ctx, true),
-                          child: const Text('Delete'),
-                        ),
-                      ],
-                    ),
-                  );
-                  if (confirm == true) {
-                    onDeleteCustomBlock!(id);
-                  }
-                }
-              : null,
+                      );
+                      if (action == 'edit' && onEditCustomBlock != null) {
+                        onEditCustomBlock!(id);
+                      } else if (action == 'delete' && onDeleteCustomBlock != null) {
+                        final confirm = await showDialog<bool>(
+                          context: context,
+                          builder: (ctx) => AlertDialog(
+                            title: const Text('Delete block?'),
+                            content: const Text('Are you sure you want to delete this block?'),
+                            actions: [
+                              TextButton(
+                                onPressed: () => Navigator.pop(ctx, false),
+                                child: const Text('Cancel'),
+                              ),
+                              TextButton(
+                                onPressed: () => Navigator.pop(ctx, true),
+                                child: const Text('Delete'),
+                              ),
+                            ],
+                          ),
+                        );
+                        if (confirm == true) {
+                          onDeleteCustomBlock!(id);
+                        }
+                      }
+                    }
+                  : null,
           child: Stack(
             children: [
               Positioned.fill(


### PR DESCRIPTION
## Summary
- allow editing existing custom blocks
- add workout selector chips in workout builder
- enable edit/delete from block grid

## Testing
- `dart` and `flutter` commands were unavailable in the environment

------
https://chatgpt.com/codex/tasks/task_e_68485565dfdc8323b1a72217b7e2cd88