### PR TITLE
Add badge board leaderboard tab

### DIFF
--- a/lib/screens/leaderboard_screen.dart
+++ b/lib/screens/leaderboard_screen.dart
@@ -1,6 +1,8 @@
-import 'package:lift_league/widgets/leaderboard_tile.dart';
 import 'package:flutter/material.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:lift_league/widgets/leaderboard_tile.dart';
+import 'package:lift_league/widgets/badge_board_tile.dart';
 
 class LeaderboardScreen extends StatelessWidget {
   final int blockId;
@@ -32,61 +34,152 @@ class LeaderboardScreen extends StatelessWidget {
     }).toList());
   }
 
+  Future<List<Map<String, dynamic>>> badgeBoard() async {
+    final firestore = FirebaseFirestore.instance;
+    final currentUserId = FirebaseAuth.instance.currentUser?.uid;
+    if (currentUserId == null) return [];
+
+    final circleSnap = await firestore
+        .collection('users')
+        .doc(currentUserId)
+        .collection('training_circle')
+        .get();
+
+    final memberIds = circleSnap.docs.map((d) => d.id).toList();
+    memberIds.add(currentUserId);
+
+    final ids = memberIds.toSet().toList();
+
+    final futures = ids.map((id) async {
+      final userDoc = await firestore.collection('users').doc(id).get();
+      final userData = userDoc.data() ?? {};
+      final badgesSnap = await firestore
+          .collection('users')
+          .doc(id)
+          .collection('badges')
+          .get();
+
+      return {
+        'userId': id,
+        'displayName': userData['displayName'] ?? 'Unknown',
+        'profileImageUrl': userData['profileImageUrl'] ?? '',
+        'title': userData['title'] ?? '',
+        'badgeCount': badgesSnap.docs.length,
+      };
+    });
+
+    final entries = await Future.wait(futures);
+    entries.sort((a, b) =>
+        (b['badgeCount'] as int).compareTo(a['badgeCount'] as int));
+    return entries;
+  }
+
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: const Text('Leaderboard')),
-      body: StreamBuilder<List<Map<String, dynamic>>>(
-        stream: leaderboardStream(),
-        builder: (context, snapshot) {
-          if (snapshot.connectionState == ConnectionState.waiting) {
-            return const Center(child: CircularProgressIndicator());
-          }
-
-          if (snapshot.hasError) {
-            return Center(
-              child: Text('Error loading leaderboard: ${snapshot.error}'),
-            );
-          }
-
-          if (!snapshot.hasData || snapshot.data!.isEmpty) {
-            return const Center(
-              child: Text(
-                'No scores yet. Be the first to log a workout!',
-                style: TextStyle(fontSize: 16),
-              ),
-            );
-          }
-
-          final data = snapshot.data!;
-
-          return Column(
-            children: [
-              const Padding(
-                padding: EdgeInsets.all(16),
-                child: Text('🏆 Top Performers', style: TextStyle(
-                    fontSize: 20, fontWeight: FontWeight.bold)),
-              ),
-              Expanded(
-                child: ListView.builder(
-                  itemCount: data.length,
-                  itemBuilder: (context, index) {
-                    final entry = data[index];
-                    return LeaderboardTile(
-                      userId: entry['userId'],
-                      displayName: entry['displayName'],
-                      profileImageUrl: entry['profileImageUrl'],
-                      blockScore: entry['blockScore'],
-                      workoutScores: List<String>.from(entry['workoutScores']),
-                      title: entry['title'],
-                    );
-                  },
-                ),
-              ),
+    return DefaultTabController(
+      length: 2,
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('Leaderboard'),
+          bottom: const TabBar(
+            tabs: [
+              Tab(text: 'Block'),
+              Tab(text: 'Badges'),
             ],
-          );
-        },
+          ),
+        ),
+        body: TabBarView(
+          children: [
+            _buildBlockLeaderboard(),
+            _buildBadgeBoard(),
+          ],
+        ),
       ),
+    );
+  }
+
+  Widget _buildBlockLeaderboard() {
+    return StreamBuilder<List<Map<String, dynamic>>>(
+      stream: leaderboardStream(),
+      builder: (context, snapshot) {
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return const Center(child: CircularProgressIndicator());
+        }
+
+        if (snapshot.hasError) {
+          return Center(
+            child: Text('Error loading leaderboard: ${snapshot.error}'),
+          );
+        }
+
+        if (!snapshot.hasData || snapshot.data!.isEmpty) {
+          return const Center(
+            child: Text(
+              'No scores yet. Be the first to log a workout!',
+              style: TextStyle(fontSize: 16),
+            ),
+          );
+        }
+
+        final data = snapshot.data!;
+
+        return Column(
+          children: [
+            const Padding(
+              padding: EdgeInsets.all(16),
+              child: Text('🏆 Top Performers',
+                  style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),
+            ),
+            Expanded(
+              child: ListView.builder(
+                itemCount: data.length,
+                itemBuilder: (context, index) {
+                  final entry = data[index];
+                  return LeaderboardTile(
+                    userId: entry['userId'],
+                    displayName: entry['displayName'],
+                    profileImageUrl: entry['profileImageUrl'],
+                    blockScore: entry['blockScore'],
+                    workoutScores: List<String>.from(entry['workoutScores']),
+                    title: entry['title'],
+                  );
+                },
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  Widget _buildBadgeBoard() {
+    return FutureBuilder<List<Map<String, dynamic>>>(
+      future: badgeBoard(),
+      builder: (context, snapshot) {
+        if (!snapshot.hasData) {
+          return const Center(child: CircularProgressIndicator());
+        }
+
+        final data = snapshot.data!;
+
+        if (data.isEmpty) {
+          return const Center(child: Text('No badges earned yet.'));
+        }
+
+        return ListView.builder(
+          itemCount: data.length,
+          itemBuilder: (context, index) {
+            final entry = data[index];
+            return BadgeBoardTile(
+              userId: entry['userId'],
+              displayName: entry['displayName'],
+              profileImageUrl: entry['profileImageUrl'],
+              title: entry['title'],
+              badgeCount: entry['badgeCount'] as int,
+            );
+          },
+        );
+      },
     );
   }
 }

--- a/lib/widgets/badge_board_tile.dart
+++ b/lib/widgets/badge_board_tile.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:lift_league/screens/public_profile_screen.dart';
+
+class BadgeBoardTile extends StatelessWidget {
+  final String userId;
+  final String displayName;
+  final String profileImageUrl;
+  final String title;
+  final int badgeCount;
+
+  const BadgeBoardTile({
+    super.key,
+    required this.userId,
+    required this.displayName,
+    required this.profileImageUrl,
+    required this.title,
+    required this.badgeCount,
+  });
+
+  bool _validUrl(String? url) {
+    return url != null && url.startsWith('http') && url.length > 30;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: () {
+        Navigator.push(
+          context,
+          MaterialPageRoute(builder: (_) => PublicProfileScreen(userId: userId)),
+        );
+      },
+      child: ListTile(
+        leading: CircleAvatar(
+          backgroundColor: Colors.grey[300],
+          backgroundImage: _validUrl(profileImageUrl)
+              ? NetworkImage(profileImageUrl)
+              : const AssetImage('assets/images/flatLogo.jpg') as ImageProvider,
+        ),
+        title: Text(
+          displayName,
+          style: const TextStyle(
+            color: Color(0xFFFC3B3D),
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        subtitle: Text(
+          title,
+          style: const TextStyle(fontStyle: FontStyle.italic),
+        ),
+        trailing: Text(
+          'Badges: $badgeCount',
+          style: const TextStyle(fontWeight: FontWeight.bold),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add tabbed layout to leaderboard screen
- include new badge board tab ranking training circle badge counts
- create BadgeBoardTile widget for badge board entries

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848da0f441c83238b20e44a225bd3da