### PR TITLE
Improve workout manager filtering

### DIFF
--- a/lib/screens/block_manager_screen.dart
+++ b/lib/screens/block_manager_screen.dart
@@ -13,12 +13,18 @@ class _WorkoutManagerScreenState extends State<WorkoutManagerScreen> {
   final DBService _db = DBService();
   final BlockManagerService _manager = BlockManagerService();
   List<Map<String, dynamic>> lifts = [];
+  List<Map<String, dynamic>> blocks = [];
+  List<Map<String, dynamic>> workouts = [];
+  int? selectedBlockId;
+  int? selectedWorkoutId;
+  bool sortAsc = true;
   bool loading = true;
   bool executing = false;
 
   @override
   void initState() {
     super.initState();
+    _loadBlocks();
     _loadLifts();
   }
 
@@ -27,6 +33,38 @@ class _WorkoutManagerScreenState extends State<WorkoutManagerScreen> {
     setState(() {
       lifts = all;
       loading = false;
+    });
+    _sortLifts();
+  }
+
+  Future<void> _loadBlocks() async {
+    final b = await _db.getAllBlocks();
+    setState(() => blocks = b);
+  }
+
+  Future<void> _loadWorkoutsForBlock(int blockId) async {
+    final w = await _db.getWorkoutsByBlockId(blockId);
+    setState(() {
+      workouts = w;
+      selectedWorkoutId = null;
+    });
+  }
+
+  Future<void> _loadLiftsForWorkout(int workoutId) async {
+    setState(() => loading = true);
+    final l = await _db.getLiftsByWorkoutId(workoutId);
+    setState(() {
+      lifts = l;
+      loading = false;
+    });
+    _sortLifts();
+  }
+
+  void _sortLifts() {
+    lifts.sort((a, b) {
+      final nameA = (a['liftName'] ?? '').toString().toLowerCase();
+      final nameB = (b['liftName'] ?? '').toString().toLowerCase();
+      return sortAsc ? nameA.compareTo(nameB) : nameB.compareTo(nameA);
     });
   }
 
@@ -42,6 +80,7 @@ class _WorkoutManagerScreenState extends State<WorkoutManagerScreen> {
         'description': '',
       });
     });
+    _sortLifts();
   }
 
   Future<void> _execute() async {
@@ -62,8 +101,9 @@ class _WorkoutManagerScreenState extends State<WorkoutManagerScreen> {
   Widget _buildLiftCard(int index) {
     final lift = lifts[index];
     return ExpansionTile(
-      title: Text(lift['liftName'] ?? 'New Lift'),
-      children: [
+        title: Text(
+            '${lift['liftName'] ?? 'New Lift'} • ${lift['repScheme'] ?? ''}'),
+        children: [
         Padding(
           padding: const EdgeInsets.all(8.0),
           child: Column(
@@ -123,21 +163,104 @@ class _WorkoutManagerScreenState extends State<WorkoutManagerScreen> {
     );
   }
 
+  Widget _buildFilterRow() {
+    return Padding(
+      padding: const EdgeInsets.all(8.0),
+      child: Row(
+        children: [
+          Expanded(
+            child: DropdownButton<int>(
+              isExpanded: true,
+              hint: const Text('Block'),
+              value: selectedBlockId,
+              items: blocks
+                  .map((b) => DropdownMenuItem<int>(
+                        value: b['blockId'] as int,
+                        child: Text(b['blockName'] as String),
+                      ))
+                  .toList(),
+              onChanged: (v) {
+                if (v == null) return;
+                setState(() {
+                  selectedBlockId = v;
+                });
+                _loadWorkoutsForBlock(v);
+              },
+            ),
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: DropdownButton<int>(
+              isExpanded: true,
+              hint: const Text('Workout'),
+              value: selectedWorkoutId,
+              items: workouts
+                  .map((w) => DropdownMenuItem<int>(
+                        value: w['workoutId'] as int,
+                        child: Text(w['workoutName'] as String),
+                      ))
+                  .toList(),
+              onChanged: (v) {
+                if (v == null) return;
+                setState(() {
+                  selectedWorkoutId = v;
+                });
+                _loadLiftsForWorkout(v);
+              },
+            ),
+          ),
+          IconButton(
+            icon: const Icon(Icons.clear),
+            onPressed: () {
+              setState(() {
+                selectedBlockId = null;
+                selectedWorkoutId = null;
+                workouts.clear();
+              });
+              _loadLifts();
+            },
+          )
+        ],
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Workout Manager')),
-      body: loading
-          ? const Center(child: CircularProgressIndicator())
-          : Stack(
-        children: [
-          ListView.builder(
-            itemCount: lifts.length,
-            itemBuilder: (c, i) => _buildLiftCard(i),
+      appBar: AppBar(
+        title: const Text('Workout Manager'),
+        actions: [
+          IconButton(
+            icon: Icon(sortAsc ? Icons.arrow_upward : Icons.arrow_downward),
+            onPressed: () {
+              setState(() {
+                sortAsc = !sortAsc;
+                _sortLifts();
+              });
+            },
           ),
-          if (executing) const Center(child: CircularProgressIndicator()),
         ],
       ),
+      body: loading
+          ? const Center(child: CircularProgressIndicator())
+          : Column(
+              children: [
+                _buildFilterRow(),
+                Expanded(
+                  child: Stack(
+                    children: [
+                      ListView.builder(
+                        itemCount: lifts.length,
+                        itemBuilder: (c, i) => _buildLiftCard(i),
+                      ),
+                      if (executing)
+                        const Center(child: CircularProgressIndicator()),
+                    ],
+                  ),
+                ),
+              ],
+            ),
       floatingActionButton: Column(
         mainAxisSize: MainAxisSize.min,
         children: [

--- a/lib/services/db_service.dart
+++ b/lib/services/db_service.dart
@@ -2244,6 +2244,28 @@ class DBService {
     );
   }
 
+  Future<List<Map<String, dynamic>>> getWorkoutsByBlockId(int blockId) async {
+    final db = await database;
+    return await db.rawQuery('''
+      SELECT wb.workoutId, w.workoutName
+      FROM workouts_blocks wb
+      JOIN workouts w ON wb.workoutId = w.workoutId
+      WHERE wb.blockId = ?
+      ORDER BY w.workoutName ASC
+    ''', [blockId]);
+  }
+
+  Future<List<Map<String, dynamic>>> getLiftsByWorkoutId(int workoutId) async {
+    final db = await database;
+    return await db.rawQuery('''
+      SELECT l.*
+      FROM lift_workouts lw
+      JOIN lifts l ON lw.liftId = l.liftId
+      WHERE lw.workoutId = ?
+      ORDER BY l.liftName ASC
+    ''', [workoutId]);
+  }
+
   Future<List<int>> getWorkoutInstancesByLift(int liftId) async {
     final db = await database;
     final res = await db.rawQuery(


### PR DESCRIPTION
## Summary
- sort lifts alphabetically by default
- show rep scheme in lift listing
- add dropdown filters for blocks and workouts
- toggle ascending/descending sorting
- expose DB helpers to get workouts and lifts for filters

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ca1ac53b483239c8f53c2d70e4f41