### PR TITLE
Refactor BlockManagerScreen

### DIFF
--- a/lib/screens/user_dashboard.dart
+++ b/lib/screens/user_dashboard.dart
@@ -617,7 +617,7 @@ class _UserDashboardState extends State<UserDashboard> {
                           Navigator.push(
                             context,
                             MaterialPageRoute(
-                                builder: (_) => const WorkoutManagerScreen()),
+                                builder: (_) => const BlockManagerScreen()),
                           );
                         },
                       ),

--- a/lib/services/db_service.dart
+++ b/lib/services/db_service.dart
@@ -2266,6 +2266,21 @@ class DBService {
     ''', [workoutId]);
   }
 
+  Future<List<Map<String, dynamic>>> getLiftsByBlockAndWorkout() async {
+    final db = await database;
+    return await db.rawQuery('''
+      SELECT b.blockId, b.blockName, w.workoutId, w.workoutName,
+             l.liftId, l.liftName, l.repScheme, l.numSets, l.scoreMultiplier,
+             l.isDumbbellLift, l.scoreType, l.youtubeUrl, l.description
+      FROM blocks b
+      JOIN workouts_blocks wb ON wb.blockId = b.blockId
+      JOIN workouts w ON wb.workoutId = w.workoutId
+      JOIN lift_workouts lw ON lw.workoutId = w.workoutId
+      JOIN lifts l ON lw.liftId = l.liftId
+      ORDER BY b.blockName ASC, w.workoutName ASC, l.liftName ASC
+    ''');
+  }
+
   Future<List<int>> getWorkoutInstancesByLift(int liftId) async {
     final db = await database;
     final res = await db.rawQuery(


### PR DESCRIPTION
## Summary
- convert WorkoutManagerScreen into BlockManagerScreen
- show lifts grouped by block and workout
- add DB helper to fetch lifts grouped by block/workout
- use new screen from the user dashboard

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ccc0e1b588323be4dedf2d1d9b86d