### PR TITLE
Add builder home menu with about and merch screens

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,7 @@
 import 'dart:ui';
 import 'package:flutter/material.dart';
 import 'package:firebase_core/firebase_core.dart';
-import 'package:lift_league/web_tools/poss_block_builder.dart';
+import 'package:lift_league/web_tools/poss_home_page.dart';
 import 'firebase_options.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
@@ -143,7 +143,7 @@ class LiftLeagueApp extends StatelessWidget {
         '/publicProfile': (context) => PublicProfileScreen(
           userId: (ModalRoute.of(context)?.settings.arguments as Map?)?['userId'] ?? '',
         ),
-        '/poss': (context) => const POSSBlockBuilder(),
+        '/poss': (context) => const POSSHomePage(),
 
       },
       home: const AuthGate(),

--- a/lib/screens/about_screen.dart
+++ b/lib/screens/about_screen.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+
+class AboutScreen extends StatelessWidget {
+  const AboutScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('About')),
+      body: const Padding(
+        padding: EdgeInsets.all(16),
+        child: Text(
+          'The Lift League helps you build and manage custom training blocks.',
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/merch_screen.dart
+++ b/lib/screens/merch_screen.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+class MerchScreen extends StatelessWidget {
+  const MerchScreen({super.key});
+
+  Future<void> _openStore() async {
+    const url = 'https://example.com/merch';
+    final uri = Uri.parse(url);
+    if (await canLaunchUrl(uri)) {
+      await launchUrl(uri);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Merch')),
+      body: Center(
+        child: ElevatedButton(
+          onPressed: _openStore,
+          child: const Text('Visit Store'),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/web_tools/custom_blocks_screen.dart
+++ b/lib/web_tools/custom_blocks_screen.dart
@@ -1,0 +1,96 @@
+import 'dart:io';
+import 'package:flutter/material.dart';
+import 'package:lift_league/services/db_service.dart';
+
+class CustomBlocksScreen extends StatefulWidget {
+  final VoidCallback onCreateNew;
+  const CustomBlocksScreen({super.key, required this.onCreateNew});
+
+  @override
+  State<CustomBlocksScreen> createState() => _CustomBlocksScreenState();
+}
+
+class _CustomBlocksScreenState extends State<CustomBlocksScreen> {
+  List<Map<String, dynamic>> _blocks = [];
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadBlocks();
+  }
+
+  Future<void> _loadBlocks() async {
+    final blocks = await DBService().getCustomBlocks(includeDrafts: true);
+    setState(() {
+      _blocks = blocks;
+      _loading = false;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_loading) return const Center(child: CircularProgressIndicator());
+    if (_blocks.isEmpty) {
+      return Center(
+        child: ElevatedButton(
+          onPressed: widget.onCreateNew,
+          child: const Text('Create Your First Block'),
+        ),
+      );
+    }
+
+    return Column(
+      children: [
+        Expanded(
+          child: GridView.builder(
+            padding: const EdgeInsets.all(10),
+            gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+              crossAxisCount: 2,
+              crossAxisSpacing: 10,
+              mainAxisSpacing: 10,
+              childAspectRatio: 1.4,
+            ),
+            itemCount: _blocks.length,
+            itemBuilder: (context, index) {
+              final b = _blocks[index];
+              final path = b['coverImagePath']?.toString() ?? 'assets/logo25.jpg';
+              final Widget imageWidget;
+              if (path.startsWith('assets/')) {
+                imageWidget = Image.asset(path, fit: BoxFit.cover);
+              } else {
+                imageWidget = Image.file(File(path), fit: BoxFit.cover);
+              }
+              return Card(
+                clipBehavior: Clip.antiAlias,
+                child: Stack(
+                  children: [
+                    Positioned.fill(child: imageWidget),
+                    Align(
+                      alignment: Alignment.bottomCenter,
+                      child: Container(
+                        color: Colors.black54,
+                        padding: const EdgeInsets.all(4),
+                        width: double.infinity,
+                        child: Text(
+                          b['name'] as String? ?? '',
+                          textAlign: TextAlign.center,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              );
+            },
+          ),
+        ),
+        const SizedBox(height: 8),
+        ElevatedButton(
+          onPressed: widget.onCreateNew,
+          child: const Text('Create Block'),
+        ),
+        const SizedBox(height: 8),
+      ],
+    );
+  }
+}

--- a/lib/web_tools/poss_block_builder.dart
+++ b/lib/web_tools/poss_block_builder.dart
@@ -11,7 +11,8 @@ import '../models/custom_block_models.dart';
 import '../screens/workout_builder.dart';
 
 class POSSBlockBuilder extends StatefulWidget {
-  const POSSBlockBuilder({super.key});
+  final VoidCallback? onSaved;
+  const POSSBlockBuilder({super.key, this.onSaved});
 
   @override
   State<POSSBlockBuilder> createState() => _POSSBlockBuilderState();
@@ -218,6 +219,7 @@ class _POSSBlockBuilderState extends State<POSSBlockBuilder> {
       ScaffoldMessenger.of(context)
           .showSnackBar(const SnackBar(content: Text('Block saved!')));
     }
+    widget.onSaved?.call();
   }
 
   @override
@@ -352,5 +354,11 @@ class _POSSBlockBuilderState extends State<POSSBlockBuilder> {
         ],
       ),
     );
+  }
+
+  @override
+  void dispose() {
+    _nameCtrl.dispose();
+    super.dispose();
   }
 }

--- a/lib/web_tools/poss_home_page.dart
+++ b/lib/web_tools/poss_home_page.dart
@@ -1,0 +1,100 @@
+import 'package:flutter/material.dart';
+import '../screens/about_screen.dart';
+import '../screens/merch_screen.dart';
+import 'custom_blocks_screen.dart';
+import 'poss_block_builder.dart';
+import '../services/db_service.dart';
+
+class POSSHomePage extends StatefulWidget {
+  const POSSHomePage({super.key});
+
+  @override
+  State<POSSHomePage> createState() => _POSSHomePageState();
+}
+
+class _POSSHomePageState extends State<POSSHomePage> {
+  bool _showGrid = false;
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _checkBlocks();
+  }
+
+  Future<void> _checkBlocks() async {
+    try {
+      final blocks = await DBService().getCustomBlocks();
+      setState(() {
+        _showGrid = blocks.isNotEmpty;
+        _loading = false;
+      });
+    } catch (_) {
+      setState(() => _loading = false);
+    }
+  }
+
+  void _onSaved() {
+    _checkBlocks();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    Widget body;
+    if (_loading) {
+      body = const Center(child: CircularProgressIndicator());
+    } else if (_showGrid) {
+      body = CustomBlocksScreen(onCreateNew: () {
+        setState(() => _showGrid = false);
+      });
+    } else {
+      body = POSSBlockBuilder(onSaved: _onSaved);
+    }
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('The Lift League')),
+      drawer: Drawer(
+        child: ListView(
+          padding: EdgeInsets.zero,
+          children: [
+            const DrawerHeader(
+              decoration: BoxDecoration(color: Colors.black54),
+              child: Text('Menu', style: TextStyle(color: Colors.white)),
+            ),
+            ListTile(
+              leading: const Icon(Icons.home),
+              title: const Text('Home'),
+              onTap: () {
+                Navigator.pop(context);
+                setState(() => _showGrid = true);
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.info),
+              title: const Text('About'),
+              onTap: () {
+                Navigator.pop(context);
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (_) => const AboutScreen()),
+                );
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.shopping_cart),
+              title: const Text('Merch'),
+              onTap: () {
+                Navigator.pop(context);
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (_) => const MerchScreen()),
+                );
+              },
+            ),
+          ],
+        ),
+      ),
+      body: body,
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add new POSS home page with navigation drawer
- show custom blocks after first one is saved
- include basic About and Merch screens
- call onSaved callback from POSSBlockBuilder and dispose controller

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f71a0e4148323b61bc6650d86b63a