### PR TITLE
Implement persistent rest timer

### DIFF
--- a/lib/services/notifications_service.dart
+++ b/lib/services/notifications_service.dart
@@ -89,4 +89,38 @@ class NotificationService {
     );
   }
 
+  static const int restTimerNotificationId = 999;
+
+  String _format(int seconds) {
+    final mins = (seconds ~/ 60).toString().padLeft(2, '0');
+    final secs = (seconds % 60).toString().padLeft(2, '0');
+    return '$mins:$secs';
+  }
+
+  Future<void> showOngoingTimerNotification(int seconds) async {
+    const AndroidNotificationDetails androidDetails = AndroidNotificationDetails(
+      'rest_timer',
+      'Rest Timer',
+      importance: Importance.max,
+      priority: Priority.high,
+      icon: 'ic_stat_liftleague',
+      ongoing: true,
+      showWhen: false,
+      onlyAlertOnce: true,
+    );
+
+    const NotificationDetails details = NotificationDetails(android: androidDetails);
+
+    await _localNotifications.show(
+      restTimerNotificationId,
+      'Rest Timer',
+      _format(seconds),
+      details,
+    );
+  }
+
+  Future<void> cancelOngoingTimerNotification() async {
+    await _localNotifications.cancel(restTimerNotificationId);
+  }
+
 }

--- a/lib/services/rest_timer_service.dart
+++ b/lib/services/rest_timer_service.dart
@@ -1,0 +1,71 @@
+import 'dart:async';
+import 'package:audioplayers/audioplayers.dart';
+import 'package:flutter/material.dart';
+import 'package:vibration/vibration.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:lift_league/services/notifications_service.dart';
+
+class RestTimerService {
+  RestTimerService._internal();
+  static final RestTimerService _instance = RestTimerService._internal();
+  factory RestTimerService() => _instance;
+
+  Timer? _timer;
+  int _remainingSeconds = 0;
+  int get remainingSeconds => _remainingSeconds;
+
+  final StreamController<int> _streamController = StreamController<int>.broadcast();
+  Stream<int> get stream => _streamController.stream;
+
+  final AudioPlayer _audioPlayer = AudioPlayer();
+  bool _playSound = true;
+
+  Future<void> _loadPrefs() async {
+    final prefs = await SharedPreferences.getInstance();
+    _playSound = prefs.getBool('playRestSound') ?? true;
+  }
+
+  Future<void> _playChime() async {
+    if (!_playSound) return;
+    try {
+      await _audioPlayer.play(AssetSource('sounds/chime.wav'));
+      await _audioPlayer.onPlayerComplete.first;
+      await _audioPlayer.release();
+    } catch (_) {}
+  }
+
+  void start(int seconds) {
+    _timer?.cancel();
+    _remainingSeconds = seconds;
+    _streamController.add(_remainingSeconds);
+    _loadPrefs();
+    NotificationService().showOngoingTimerNotification(_remainingSeconds);
+
+    _timer = Timer.periodic(const Duration(seconds: 1), (timer) async {
+      if (_remainingSeconds > 1) {
+        _remainingSeconds--;
+        _streamController.add(_remainingSeconds);
+        NotificationService().showOngoingTimerNotification(_remainingSeconds);
+      } else {
+        timer.cancel();
+        _remainingSeconds = 0;
+        _streamController.add(_remainingSeconds);
+        NotificationService().cancelOngoingTimerNotification();
+        Vibration.hasVibrator().then((hasVibrator) {
+          if (hasVibrator ?? false) {
+            Vibration.vibrate(duration: 500);
+          }
+        });
+        await _playChime();
+      }
+    });
+  }
+
+  void stop() {
+    _timer?.cancel();
+    _remainingSeconds = 0;
+    _streamController.add(_remainingSeconds);
+    NotificationService().cancelOngoingTimerNotification();
+  }
+}


### PR DESCRIPTION
## Summary
- add RestTimerService to handle rest countdown globally
- display countdown via persistent notification on lock screen
- restore previous audio when alarm finishes
- update RestTimer widget to use the new service
- extend NotificationService with helper functions for ongoing timer

## Testing
- `flutter analyze` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68502bd6816883239b0baf9ed2e463ad