### PR TITLE
Revise POSS home page

### DIFF
--- a/lib/web_tools/poss_home_page.dart
+++ b/lib/web_tools/poss_home_page.dart
@@ -48,11 +48,22 @@ class _POSSHomePageState extends State<POSSHomePage> {
         setState(() => _showGrid = false);
       });
     } else {
-      body = POSSBlockBuilder(onSaved: _onSaved);
+      body = const Center(child: Text('There are no saved blocks yet'));
     }
 
     return Scaffold(
-      appBar: AppBar(title: const Text('The Lift League')),
+      appBar: AppBar(
+        title: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: const [
+            Text('The Lift League'),
+            Text(
+              'Progressive Overload Scoring System',
+              style: TextStyle(fontSize: 14),
+            ),
+          ],
+        ),
+      ),
       drawer: Drawer(
         child: ListView(
           padding: EdgeInsets.zero,


### PR DESCRIPTION
## Summary
- add header subtitle to POSS home page
- show a message when no custom blocks are found

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart format lib/web_tools/poss_home_page.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68504fd2e9cc83238a83cf40960ad8ca