### PR TITLE
Add follower and training circle lists

### DIFF
--- a/lib/screens/following_screen.dart
+++ b/lib/screens/following_screen.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'public_profile_screen.dart';
+
+class FollowingScreen extends StatelessWidget {
+  const FollowingScreen({super.key});
+
+  Future<List<Map<String, dynamic>>> _fetchFollowing() async {
+    final currentUserId = FirebaseAuth.instance.currentUser?.uid;
+    if (currentUserId == null) return [];
+    final snap = await FirebaseFirestore.instance
+        .collection('users')
+        .doc(currentUserId)
+        .collection('following')
+        .get();
+
+    return snap.docs.map((doc) {
+      final data = doc.data();
+      return {
+        'userId': doc.id,
+        'displayName': data['displayName'] ?? 'Unknown',
+        'profileImageUrl': data['profileImageUrl'] ?? '',
+        'title': data['title'] ?? '',
+      };
+    }).toList();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Following'),
+        backgroundColor: Colors.black,
+      ),
+      backgroundColor: Colors.black,
+      body: FutureBuilder<List<Map<String, dynamic>>>(
+        future: _fetchFollowing(),
+        builder: (context, snapshot) {
+          if (!snapshot.hasData) {
+            return const Center(child: CircularProgressIndicator());
+          }
+
+          final users = snapshot.data!;
+          if (users.isEmpty) {
+            return const Center(
+              child: Text(
+                'You are not following anyone.',
+                style: TextStyle(color: Colors.white70),
+              ),
+            );
+          }
+
+          return ListView.builder(
+            itemCount: users.length,
+            itemBuilder: (context, index) {
+              final user = users[index];
+              final profileUrl = user['profileImageUrl'];
+              return ListTile(
+                leading: CircleAvatar(
+                  backgroundImage: (profileUrl != null &&
+                          profileUrl.toString().startsWith('http'))
+                      ? NetworkImage(profileUrl)
+                      : const AssetImage('assets/images/flatLogo.jpg')
+                          as ImageProvider,
+                ),
+                title: Text(
+                  user['displayName'] ?? 'Unknown',
+                  style: const TextStyle(
+                      color: Color(0xFFFC3B3D), fontWeight: FontWeight.bold),
+                ),
+                subtitle: Text(
+                  user['title'] ?? '',
+                  style: const TextStyle(
+                    color: Colors.white70,
+                    fontStyle: FontStyle.italic,
+                    fontSize: 12,
+                  ),
+                ),
+                onTap: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => PublicProfileScreen(
+                        userId: user['userId'],
+                      ),
+                    ),
+                  );
+                },
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/screens/public_profile_screen.dart
+++ b/lib/screens/public_profile_screen.dart
@@ -4,6 +4,8 @@ import 'package:lift_league/widgets/timeline_public.dart';
 import 'user_stats_screen.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'chat_screen.dart';
+import 'following_screen.dart';
+import 'training_circle_members_screen.dart';
 import 'package:lift_league/services/user_follow_service.dart';
 import 'package:lift_league/services/db_service.dart';
 import 'package:lift_league/models/custom_block_models.dart';
@@ -281,18 +283,43 @@ class _PublicProfileScreenState extends State<PublicProfileScreen> {
                           icon: Icons.bar_chart,
                           onPressed: showStats
                               ? () {
-                            Navigator.push(
-                              context,
-                              MaterialPageRoute(
-                                builder: (_) => UserStatsScreen(
-                                  userId: widget.userId,
-                                  showCheckInGraph: false,
-                                ),
-                              ),
-                            );
-                          }
+                                  Navigator.push(
+                                    context,
+                                    MaterialPageRoute(
+                                      builder: (_) => UserStatsScreen(
+                                        userId: widget.userId,
+                                        showCheckInGraph: false,
+                                      ),
+                                    ),
+                                  );
+                                }
                               : null,
                         ),
+                        if (widget.userId == currentUserId) ...[
+                          const SizedBox(width: 16),
+                          _iconRectButton(
+                            icon: Icons.list_alt,
+                            onPressed: () {
+                              Navigator.push(
+                                context,
+                                MaterialPageRoute(
+                                    builder: (_) => const FollowingScreen()),
+                              );
+                            },
+                          ),
+                          const SizedBox(width: 16),
+                          _iconRectButton(
+                            icon: Icons.group,
+                            onPressed: () {
+                              Navigator.push(
+                                context,
+                                MaterialPageRoute(
+                                    builder: (_) =>
+                                        const TrainingCircleMembersScreen()),
+                              );
+                            },
+                          ),
+                        ],
                         if (widget.userId != currentUserId) ...[
                           const SizedBox(width: 16),
                           _iconRectButton(

--- a/lib/screens/training_circle_members_screen.dart
+++ b/lib/screens/training_circle_members_screen.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'public_profile_screen.dart';
+
+class TrainingCircleMembersScreen extends StatelessWidget {
+  const TrainingCircleMembersScreen({super.key});
+
+  Future<List<Map<String, dynamic>>> _fetchMembers() async {
+    final currentUserId = FirebaseAuth.instance.currentUser?.uid;
+    if (currentUserId == null) return [];
+    final snap = await FirebaseFirestore.instance
+        .collection('users')
+        .doc(currentUserId)
+        .collection('training_circle')
+        .get();
+
+    return snap.docs.map((doc) {
+      final data = doc.data();
+      return {
+        'userId': doc.id,
+        'displayName': data['displayName'] ?? 'Unknown',
+        'profileImageUrl': data['profileImageUrl'] ?? '',
+        'title': data['title'] ?? '',
+      };
+    }).toList();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Training Circle'),
+        backgroundColor: Colors.black,
+      ),
+      backgroundColor: Colors.black,
+      body: FutureBuilder<List<Map<String, dynamic>>>(
+        future: _fetchMembers(),
+        builder: (context, snapshot) {
+          if (!snapshot.hasData) {
+            return const Center(child: CircularProgressIndicator());
+          }
+
+          final users = snapshot.data!;
+          if (users.isEmpty) {
+            return const Center(
+              child: Text(
+                'Your training circle is empty.',
+                style: TextStyle(color: Colors.white70),
+              ),
+            );
+          }
+
+          return ListView.builder(
+            itemCount: users.length,
+            itemBuilder: (context, index) {
+              final user = users[index];
+              final profileUrl = user['profileImageUrl'];
+              return ListTile(
+                leading: CircleAvatar(
+                  backgroundImage: (profileUrl != null &&
+                          profileUrl.toString().startsWith('http'))
+                      ? NetworkImage(profileUrl)
+                      : const AssetImage('assets/images/flatLogo.jpg')
+                          as ImageProvider,
+                ),
+                title: Text(
+                  user['displayName'] ?? 'Unknown',
+                  style: const TextStyle(
+                      color: Color(0xFFFC3B3D), fontWeight: FontWeight.bold),
+                ),
+                subtitle: Text(
+                  user['title'] ?? '',
+                  style: const TextStyle(
+                    color: Colors.white70,
+                    fontStyle: FontStyle.italic,
+                    fontSize: 12,
+                  ),
+                ),
+                onTap: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => PublicProfileScreen(
+                        userId: user['userId'],
+                      ),
+                    ),
+                  );
+                },
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `FollowingScreen` to list followed lifters
- add `TrainingCircleMembersScreen` to list training circle members
- import and link to new screens from `PublicProfileScreen`
- show list and training circle icons when viewing your own profile

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850aaa372248323b9ae6a7126169861