### PR TITLE
Retrieve active block for stats

### DIFF
--- a/lib/services/db_service.dart
+++ b/lib/services/db_service.dart
@@ -1857,6 +1857,25 @@ class DBService {
     return result.first['blockInstanceId'] as int;
   }
 
+  /// Returns the block instance ID marked as `active` for the given [userId].
+  ///
+  /// If no active block exists, `null` is returned.
+  Future<String?> getActiveBlockInstanceId(String userId) async {
+    final db = await database;
+    final result = await db.query(
+      'block_instances',
+      columns: ['blockInstanceId'],
+      where: 'userId = ? AND status = ?',
+      whereArgs: [userId, 'active'],
+      limit: 1,
+    );
+
+    if (result.isNotEmpty && result.first['blockInstanceId'] != null) {
+      return result.first['blockInstanceId'].toString();
+    }
+    return null;
+  }
+
   Future<void> upsertBlockTotals({
     required int blockInstanceId,
     required String userId,


### PR DESCRIPTION
## Summary
- add DBService helper to get the active block instance id
- pull the active block when no id is provided on the stats screen
- use that id for Consistency and Efficiency meters

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850cb9ec524832396aefa0d9cda1a47