### PR TITLE
Update FollowingScreen with user info and follow controls

### DIFF
--- a/lib/screens/following_screen.dart
+++ b/lib/screens/following_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'public_profile_screen.dart';
+import '../services/user_follow_service.dart';
 
 class FollowingScreen extends StatelessWidget {
   const FollowingScreen({super.key});
@@ -9,21 +10,38 @@ class FollowingScreen extends StatelessWidget {
   Future<List<Map<String, dynamic>>> _fetchFollowing() async {
     final currentUserId = FirebaseAuth.instance.currentUser?.uid;
     if (currentUserId == null) return [];
+
     final snap = await FirebaseFirestore.instance
         .collection('users')
         .doc(currentUserId)
         .collection('following')
         .get();
 
-    return snap.docs.map((doc) {
+    final List<Map<String, dynamic>> result = [];
+
+    for (final doc in snap.docs) {
+      Map<String, dynamic>? userData;
+      try {
+        final userDoc = await FirebaseFirestore.instance
+            .collection('users')
+            .doc(doc.id)
+            .get();
+        userData = userDoc.data();
+      } catch (_) {
+        userData = null;
+      }
+
       final data = doc.data();
-      return {
+      result.add({
         'userId': doc.id,
-        'displayName': data['displayName'] ?? 'Unknown',
-        'profileImageUrl': data['profileImageUrl'] ?? '',
-        'title': data['title'] ?? '',
-      };
-    }).toList();
+        'displayName': userData?['displayName'] ?? data['displayName'] ?? 'Unknown',
+        'profileImageUrl':
+            userData?['profileImageUrl'] ?? data['profileImageUrl'] ?? '',
+        'title': userData?['title'] ?? data['title'] ?? '',
+      });
+    }
+
+    return result;
   }
 
   @override
@@ -55,42 +73,81 @@ class FollowingScreen extends StatelessWidget {
             itemCount: users.length,
             itemBuilder: (context, index) {
               final user = users[index];
-              final profileUrl = user['profileImageUrl'];
-              return ListTile(
-                leading: CircleAvatar(
-                  backgroundImage: (profileUrl != null &&
-                          profileUrl.toString().startsWith('http'))
-                      ? NetworkImage(profileUrl)
-                      : const AssetImage('assets/images/flatLogo.jpg')
-                          as ImageProvider,
-                ),
-                title: Text(
-                  user['displayName'] ?? 'Unknown',
-                  style: const TextStyle(
-                      color: Color(0xFFFC3B3D), fontWeight: FontWeight.bold),
-                ),
-                subtitle: Text(
-                  user['title'] ?? '',
-                  style: const TextStyle(
-                    color: Colors.white70,
-                    fontStyle: FontStyle.italic,
-                    fontSize: 12,
-                  ),
-                ),
-                onTap: () {
-                  Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                      builder: (_) => PublicProfileScreen(
-                        userId: user['userId'],
-                      ),
-                    ),
-                  );
-                },
-              );
+              return _FollowingTile(user: user);
             },
           );
         },
+      ),
+    );
+  }
+}
+
+class _FollowingTile extends StatefulWidget {
+  final Map<String, dynamic> user;
+
+  const _FollowingTile({required this.user});
+
+  @override
+  State<_FollowingTile> createState() => _FollowingTileState();
+}
+
+class _FollowingTileState extends State<_FollowingTile> {
+  late bool isFollowing;
+
+  @override
+  void initState() {
+    super.initState();
+    isFollowing = true;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final user = widget.user;
+    final profileUrl = user['profileImageUrl'];
+
+    return ListTile(
+      onTap: () {
+        Navigator.push(
+          context,
+          MaterialPageRoute(
+            builder: (_) => PublicProfileScreen(userId: user['userId']),
+          ),
+        );
+      },
+      leading: CircleAvatar(
+        backgroundImage: profileUrl != null &&
+                profileUrl.toString().startsWith('http')
+            ? NetworkImage(profileUrl)
+            : const AssetImage('assets/images/flatLogo.jpg') as ImageProvider,
+      ),
+      title: Text(
+        user['displayName'] ?? 'Unknown',
+        style: const TextStyle(
+            color: Color(0xFFFC3B3D), fontWeight: FontWeight.bold),
+      ),
+      subtitle: Text(
+        user['title'] ?? '',
+        style: const TextStyle(
+          color: Colors.white70,
+          fontStyle: FontStyle.italic,
+          fontSize: 12,
+        ),
+      ),
+      trailing: ElevatedButton(
+        onPressed: () async {
+          final currentUserId = FirebaseAuth.instance.currentUser?.uid;
+          if (currentUserId == null) return;
+          if (isFollowing) {
+            await UserFollowService().unfollowUser(currentUserId, user['userId']);
+          } else {
+            await UserFollowService().followUser(currentUserId, user['userId']);
+          }
+          setState(() => isFollowing = !isFollowing);
+        },
+        style: ElevatedButton.styleFrom(
+          backgroundColor: isFollowing ? Colors.red : Colors.blue,
+        ),
+        child: Text(isFollowing ? 'Unfollow' : 'Follow'),
       ),
     );
   }


### PR DESCRIPTION
## Summary
- refresh FollowingScreen data from user documents
- display each followed user via `_FollowingTile`
- show avatar, name, title
- add button to follow/unfollow

## Testing
- `dart` was not available so formatting/tests could not be executed

------
https://chatgpt.com/codex/tasks/task_e_6850d457d6a48323bb3c431215f5cf5e