### PR TITLE
Add rotating promo popup

### DIFF
--- a/lib/screens/block_summary.dart
+++ b/lib/screens/block_summary.dart
@@ -3,6 +3,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:lift_league/screens/user_dashboard.dart';
 import 'package:lift_league/services/user_stats_service.dart';
 import 'package:lift_league/widgets/badge_grid.dart';
+import 'package:lift_league/services/promo_popup_service.dart';
 
 class BlockSummaryScreen extends StatefulWidget {
   final int blockInstanceId;
@@ -31,6 +32,9 @@ class _BlockSummaryScreenState extends State<BlockSummaryScreen> {
   void initState() {
     super.initState();
     _loadSummaryData();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      PromoPopupService().showPromoDialog(context);
+    });
   }
 
   Future<void> _loadSummaryData() async {

--- a/lib/screens/workout_log.dart
+++ b/lib/screens/workout_log.dart
@@ -16,6 +16,7 @@ import 'package:lift_league/services/leaderboard_service.dart';
 import 'package:lift_league/modals/numpad_modal.dart';
 import 'package:lift_league/services/pr_service.dart';
 import 'package:lift_league/services/consistency_service.dart';
+import 'package:lift_league/services/promo_popup_service.dart';
 
 
 class WorkoutLogScreen extends StatefulWidget {
@@ -433,6 +434,10 @@ class WorkoutLogScreenState extends State<WorkoutLogScreen> with SingleTickerPro
       );
     } else {
       _navigateAfterWorkout(remaining);
+    }
+
+    if (mounted) {
+      await PromoPopupService().showPromoDialog(context);
     }
   }
 

--- a/lib/services/promo_popup_service.dart
+++ b/lib/services/promo_popup_service.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+class PromoPopupService {
+  PromoPopupService._internal();
+  static final PromoPopupService _instance = PromoPopupService._internal();
+  factory PromoPopupService() => _instance;
+
+  static const _prefsKey = 'promoMessageIndex';
+  static const _messages = [
+    'Want more training options? Unlock all Lift League blocks in the mobile app.',
+    'See how you stack up! Join The Lift League app for real-time leaderboards.',
+    'Earn badges for consistency and PRs—track your progress with The Lift League app.',
+    'Dig into your progress with a full stats dashboard—available in The Lift League mobile app.',
+    'Get inspired—follow other lifters and share your progress in the app!',
+    'Get video form tips for every lift—available in The Lift League app.',
+    'Looking for something? Use the powerful search tool in The Lift League app.',
+    'Stay motivated with your crew—create a Training Circle in the app.',
+    'See detailed block summaries and celebrate your wins in The Lift League app.',
+    'Share check-ins, track photos, and see your transformation—only in the app.',
+    'Drop a ‘clink’ after a great session and connect with your team—try the app!',
+    'Chat with your Training Circle and friends in The Lift League app.',
+    'Get notified when your friends hit milestones—enable notifications in the app.',
+    'Visualize your fitness journey with your personal timeline—start in the app!',
+    'Compare your before & after photos and see real progress—feature available in the app!',
+  ];
+
+  Future<void> showPromoDialog(BuildContext context) async {
+    final prefs = await SharedPreferences.getInstance();
+    int index = prefs.getInt(_prefsKey) ?? 0;
+    final message = _messages[index % _messages.length];
+
+    await showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        backgroundColor: Colors.grey[900],
+        title: const Text('Try The Lift League App'),
+        content: Text(message),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('Maybe later'),
+          ),
+          ElevatedButton(
+            onPressed: () async {
+              const url = 'https://theliftleague.com/app';
+              final uri = Uri.parse(url);
+              if (await canLaunchUrl(uri)) {
+                await launchUrl(uri);
+              }
+              if (context.mounted) Navigator.pop(context);
+            },
+            child: const Text('Get the App'),
+          ),
+        ],
+      ),
+    );
+
+    index = (index + 1) % _messages.length;
+    await prefs.setInt(_prefsKey, index);
+  }
+}

--- a/lib/web_tools/poss_home_page.dart
+++ b/lib/web_tools/poss_home_page.dart
@@ -3,6 +3,7 @@ import 'about_screen.dart';
 import 'custom_blocks_screen.dart';
 import 'poss_block_builder.dart';
 import '../services/db_service.dart';
+import '../services/promo_popup_service.dart';
 
 const Color _lightGrey = Color(0xFFD0D0D0);
 
@@ -37,6 +38,7 @@ class _POSSHomePageState extends State<POSSHomePage> {
 
   void _onSaved() {
     _checkBlocks();
+    PromoPopupService().showPromoDialog(context);
   }
 
   @override
@@ -91,7 +93,8 @@ class _POSSHomePageState extends State<POSSHomePage> {
                   Navigator.pop(context);
                   Navigator.push(
                     context,
-                    MaterialPageRoute(builder: (_) => const POSSBlockBuilder()),
+                    MaterialPageRoute(
+                        builder: (_) => POSSBlockBuilder(onSaved: _onSaved)),
                   );
                 },
               ),


### PR DESCRIPTION
## Summary
- add `PromoPopupService` with rotating messages encouraging the mobile app
- trigger a promo after saving a block in the POSS builder
- show the promo when a workout is completed
- show the promo after finishing a block

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850d87c74b0832398511b8ccb5bbd64