### PR TITLE
Add health data providers

### DIFF
--- a/lib/services/health/apple_health_provider.dart
+++ b/lib/services/health/apple_health_provider.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+import 'package:health/health.dart';
+
+import 'health_data_provider.dart';
+
+class AppleHealthProvider implements HealthDataProvider {
+  final HealthFactory _health = HealthFactory();
+
+  Future<bool> requestAuthorization() async {
+    final types = <HealthDataType>[]; // TODO: specify data types
+    return _health.requestAuthorization(types);
+  }
+
+  @override
+  Future<List<HealthSample>> fetch(DateTimeRange range) async {
+    // TODO: fetch data from Apple Health
+    return [];
+  }
+
+  @override
+  Stream<HealthSample> watchChanges() {
+    // TODO: implement change stream via HealthFactory
+    return const Stream.empty();
+  }
+}

--- a/lib/services/health/fitbit_provider.dart
+++ b/lib/services/health/fitbit_provider.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import 'package:health/health.dart';
+import 'package:fitbitter/fitbitter.dart';
+
+import 'health_data_provider.dart';
+
+class FitbitProvider implements HealthDataProvider {
+  final String? accessToken;
+
+  FitbitProvider({this.accessToken});
+
+  @override
+  Future<List<HealthSample>> fetch(DateTimeRange range) async {
+    // TODO: use Fitbitter to fetch data with [accessToken]
+    return [];
+  }
+
+  @override
+  Stream<HealthSample> watchChanges() {
+    // Fitbit does not support realtime updates in this stub
+    return const Stream.empty();
+  }
+}

--- a/lib/services/health/google_fit_provider.dart
+++ b/lib/services/health/google_fit_provider.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+import 'package:health/health.dart';
+
+import 'health_data_provider.dart';
+
+class GoogleFitProvider implements HealthDataProvider {
+  final HealthFactory _health = HealthFactory(useHealthConnectIfAvailable: true);
+
+  Future<bool> requestAuthorization() async {
+    final types = <HealthDataType>[]; // TODO: specify data types
+    return _health.requestAuthorization(types);
+  }
+
+  @override
+  Future<List<HealthSample>> fetch(DateTimeRange range) async {
+    // TODO: fetch data from Google Fit
+    return [];
+  }
+
+  @override
+  Stream<HealthSample> watchChanges() {
+    // TODO: implement change stream via HealthFactory
+    return const Stream.empty();
+  }
+}

--- a/lib/services/health/health_data_provider.dart
+++ b/lib/services/health/health_data_provider.dart
@@ -1,0 +1,7 @@
+import 'package:flutter/material.dart';
+import 'package:health/health.dart';
+
+abstract class HealthDataProvider {
+  Future<List<HealthSample>> fetch(DateTimeRange range);
+  Stream<HealthSample> watchChanges();
+}

--- a/lib/services/health/health_service.dart
+++ b/lib/services/health/health_service.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+
+import 'apple_health_provider.dart';
+import 'fitbit_provider.dart';
+import 'google_fit_provider.dart';
+import 'health_data_provider.dart';
+
+class HealthService {
+  final List<HealthDataProvider> _providers = [];
+
+  void registerAvailableProviders() {
+    // In a real implementation you would check platform/permissions
+    _providers.clear();
+    // These are stubs, but we register them so callers can use the facade
+    _providers.add(AppleHealthProvider());
+    _providers.add(GoogleFitProvider());
+    _providers.add(FitbitProvider());
+  }
+
+  Future<void> sync(DateTimeRange range) async {
+    for (final provider in _providers) {
+      try {
+        await provider.fetch(range);
+      } catch (_) {
+        // ignore individual provider errors
+      }
+    }
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -58,6 +58,14 @@ dependencies:
   firebase_messaging: ^15.2.6
   flutter_local_notifications: ^19.2.1
   fl_chart: ^1.0.0
+  health: ^4.0.0
+  health_kit_reporter: ^2.4.0      # iOS only
+  health_connect: ^1.1.0           # Android 14+ (optional)
+  fitbitter: ^2.1.0                # Fitbit REST
+  flutter_secure_storage: ^9.0.0
+  dio: ^5.4.0
+  permission_handler: ^11.3.0
+  workmanager: ^0.5.0              # background sync
 
 
 dev_dependencies:


### PR DESCRIPTION
## Summary
- add Fitbit and HealthKit dependencies
- create HealthDataProvider interface and stub health data providers for Apple, Google and Fitbit
- provide HealthService facade to sync providers

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685188f1750c83239d7adc6a4ca5706f