### PR TITLE
Add Connected Apps screen with health permissions

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -17,6 +17,7 @@ import 'package:lift_league/screens/login_screen.dart';
 import 'package:lift_league/screens/add_check_in_screen.dart';
 import 'package:lift_league/screens/custom_block_wizard.dart';
 import 'package:lift_league/screens/public_profile_screen.dart';
+import 'package:lift_league/screens/settings/connected_apps_screen.dart';
 import 'package:lift_league/services/notifications_service.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 
@@ -174,6 +175,7 @@ class LiftLeagueApp extends StatelessWidget {
           userId: (ModalRoute.of(context)?.settings.arguments as Map?)?['userId'] ?? '',
         ),
         '/poss': (context) => const POSSHomePage(),
+        '/connectedApps': (context) => const ConnectedAppsScreen(),
 
       },
       home: const AuthGate(),

--- a/lib/screens/settings/connected_apps_screen.dart
+++ b/lib/screens/settings/connected_apps_screen.dart
@@ -1,0 +1,104 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import '../../services/health/apple_health_provider.dart';
+import '../../services/health/google_fit_provider.dart';
+import '../../services/health/fitbit_provider.dart';
+
+class ConnectedAppsScreen extends StatefulWidget {
+  const ConnectedAppsScreen({super.key});
+
+  @override
+  State<ConnectedAppsScreen> createState() => _ConnectedAppsScreenState();
+}
+
+class _ConnectedAppsScreenState extends State<ConnectedAppsScreen> {
+  final _storage = const FlutterSecureStorage();
+  final _appleProvider = AppleHealthProvider();
+  final _googleProvider = GoogleFitProvider();
+  final _fitbitProvider = FitbitProvider();
+
+  bool _apple = false;
+  bool _google = false;
+  bool _fitbit = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadConnections();
+  }
+
+  Future<void> _loadConnections() async {
+    final apple = await _storage.read(key: AppleHealthProvider.connectedKey);
+    final google = await _storage.read(key: GoogleFitProvider.connectedKey);
+    final fitbit = await _storage.read(key: FitbitProvider.connectedKey);
+
+    setState(() {
+      _apple = apple == 'true';
+      _google = google == 'true';
+      _fitbit = fitbit == 'true';
+    });
+  }
+
+  Future<void> _toggleApple(bool value) async {
+    if (value) {
+      final granted = await _appleProvider.requestAuthorization();
+      if (!granted) return;
+    } else {
+      await _appleProvider.disconnect();
+    }
+    setState(() => _apple = value);
+  }
+
+  Future<void> _toggleGoogle(bool value) async {
+    if (value) {
+      final granted = await _googleProvider.requestAuthorization();
+      if (!granted) return;
+    } else {
+      await _googleProvider.disconnect();
+    }
+    setState(() => _google = value);
+  }
+
+  Future<void> _toggleFitbit(bool value) async {
+    if (value) {
+      final ok = await _fitbitProvider.authorize();
+      if (!ok) return;
+    } else {
+      await _fitbitProvider.disconnect();
+    }
+    setState(() => _fitbit = value);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Connected Apps'),
+        backgroundColor: Colors.black,
+      ),
+      backgroundColor: Colors.black,
+      body: ListView(
+        children: [
+          SwitchListTile(
+            activeColor: Colors.green,
+            title: const Text('Apple Health', style: TextStyle(color: Colors.white)),
+            value: _apple,
+            onChanged: _toggleApple,
+          ),
+          SwitchListTile(
+            activeColor: Colors.green,
+            title: const Text('Google Fit', style: TextStyle(color: Colors.white)),
+            value: _google,
+            onChanged: _toggleGoogle,
+          ),
+          SwitchListTile(
+            activeColor: Colors.green,
+            title: const Text('Fitbit', style: TextStyle(color: Colors.white)),
+            value: _fitbit,
+            onChanged: _toggleFitbit,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -322,6 +322,11 @@ class _SettingsScreenState extends State<SettingsScreen> {
               ),
             ],
           ),
+          ListTile(
+            leading: const Icon(Icons.fitness_center, color: Colors.white),
+            title: const Text('Connected Apps', style: TextStyle(color: Colors.white)),
+            onTap: () => Navigator.pushNamed(context, '/connectedApps'),
+          ),
           ExpansionTile(
             leading: const Icon(Icons.notifications, color: Colors.white),
             title: const Text('Notifications', style: TextStyle(color: Colors.white)),

--- a/lib/services/health/apple_health_provider.dart
+++ b/lib/services/health/apple_health_provider.dart
@@ -1,14 +1,28 @@
 import 'package:flutter/material.dart';
 import 'package:health/health.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
 import 'health_data_provider.dart';
 
 class AppleHealthProvider implements HealthDataProvider {
   final HealthFactory _health = HealthFactory();
+  final FlutterSecureStorage _storage = const FlutterSecureStorage();
+
+  static const connectedKey = 'appleHealthConnected';
 
   Future<bool> requestAuthorization() async {
-    final types = <HealthDataType>[]; // TODO: specify data types
-    return _health.requestAuthorization(types);
+    final types = <HealthDataType>[HealthDataType.STEPS, HealthDataType.ACTIVE_ENERGY_BURNED];
+    final granted = await _health.requestAuthorization(types);
+    if (granted) {
+      await _storage.write(key: connectedKey, value: 'true');
+    }
+    return granted;
+  }
+
+  Future<bool> isConnected() async => (await _storage.read(key: connectedKey)) == 'true';
+
+  Future<void> disconnect() async {
+    await _storage.delete(key: connectedKey);
   }
 
   @override

--- a/lib/services/health/fitbit_provider.dart
+++ b/lib/services/health/fitbit_provider.dart
@@ -1,13 +1,56 @@
 import 'package:flutter/material.dart';
 import 'package:health/health.dart';
 import 'package:fitbitter/fitbitter.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_appauth/flutter_appauth.dart';
 
 import 'health_data_provider.dart';
 
 class FitbitProvider implements HealthDataProvider {
-  final String? accessToken;
+  final FlutterSecureStorage _storage = const FlutterSecureStorage();
+  final FlutterAppAuth _appAuth = const FlutterAppAuth();
+
+  static const connectedKey = 'fitbitConnected';
+  static const tokenKey = 'fitbitAccessToken';
+  static const refreshKey = 'fitbitRefreshToken';
+
+  String? accessToken;
 
   FitbitProvider({this.accessToken});
+
+  Future<bool> authorize() async {
+    final result = await _appAuth.authorizeAndExchangeCode(
+      AuthorizationTokenRequest(
+        '<your_client_id>',
+        '<your_redirect_uri>',
+        serviceConfiguration: const AuthorizationServiceConfiguration(
+          authorizationEndpoint: 'https://www.fitbit.com/oauth2/authorize',
+          tokenEndpoint: 'https://api.fitbit.com/oauth2/token',
+        ),
+        scopes: ['activity', 'heartrate', 'sleep', 'nutrition', 'profile'],
+      ),
+    );
+
+    if (result != null) {
+      accessToken = result.accessToken;
+      await _storage.write(key: tokenKey, value: result.accessToken);
+      if (result.refreshToken != null) {
+        await _storage.write(key: refreshKey, value: result.refreshToken);
+      }
+      await _storage.write(key: connectedKey, value: 'true');
+      return true;
+    }
+    return false;
+  }
+
+  Future<bool> isConnected() async => (await _storage.read(key: connectedKey)) == 'true';
+
+  Future<void> disconnect() async {
+    accessToken = null;
+    await _storage.delete(key: tokenKey);
+    await _storage.delete(key: refreshKey);
+    await _storage.delete(key: connectedKey);
+  }
 
   @override
   Future<List<HealthSample>> fetch(DateTimeRange range) async {

--- a/lib/services/health/google_fit_provider.dart
+++ b/lib/services/health/google_fit_provider.dart
@@ -1,14 +1,28 @@
 import 'package:flutter/material.dart';
 import 'package:health/health.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
 import 'health_data_provider.dart';
 
 class GoogleFitProvider implements HealthDataProvider {
   final HealthFactory _health = HealthFactory(useHealthConnectIfAvailable: true);
+  final FlutterSecureStorage _storage = const FlutterSecureStorage();
+
+  static const connectedKey = 'googleFitConnected';
 
   Future<bool> requestAuthorization() async {
-    final types = <HealthDataType>[]; // TODO: specify data types
-    return _health.requestAuthorization(types);
+    final types = <HealthDataType>[HealthDataType.STEPS, HealthDataType.ACTIVE_ENERGY_BURNED];
+    final granted = await _health.requestAuthorization(types);
+    if (granted) {
+      await _storage.write(key: connectedKey, value: 'true');
+    }
+    return granted;
+  }
+
+  Future<bool> isConnected() async => (await _storage.read(key: connectedKey)) == 'true';
+
+  Future<void> disconnect() async {
+    await _storage.delete(key: connectedKey);
   }
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -61,6 +61,7 @@ dependencies:
   health: ^13.1.0
   health_kit_reporter: ^2.3.1     # iOS only
   fitbitter: ^2.0.4             # Fitbit REST
+  flutter_appauth: ^6.0.2
   flutter_secure_storage: ^9.0.0
   dio: ^5.4.0
   permission_handler: ^11.3.0


### PR DESCRIPTION
## Summary
- extend health provider stubs to request permissions and store flags
- implement Fitbit OAuth using `flutter_appauth`
- create `ConnectedAppsScreen` for Apple Health, Google Fit and Fitbit
- expose screen via new `/connectedApps` route
- link screen from Settings and update dependencies

## Testing
- `flutter test` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851a26d0e10832394707225af89a676