### PR TITLE
Implement health background sync

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -19,6 +19,7 @@ import 'package:lift_league/screens/custom_block_wizard.dart';
 import 'package:lift_league/screens/public_profile_screen.dart';
 import 'package:lift_league/screens/settings/connected_apps_screen.dart';
 import 'package:lift_league/services/notifications_service.dart';
+import 'package:lift_league/services/health/health_service.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 
 late FirebaseAnalytics analytics;
@@ -83,6 +84,8 @@ void main() async {
   await Firebase.initializeApp(
     options: DefaultFirebaseOptions.currentPlatform,
   );
+
+  HealthService().registerBackgroundSync();
 
   analytics = FirebaseAnalytics.instance;
 

--- a/lib/services/health/apple_health_provider.dart
+++ b/lib/services/health/apple_health_provider.dart
@@ -3,6 +3,7 @@ import 'package:health/health.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
 import 'health_data_provider.dart';
+import '../db_service.dart';
 
 class AppleHealthProvider implements HealthDataProvider {
   final HealthFactory _health = HealthFactory();
@@ -27,7 +28,18 @@ class AppleHealthProvider implements HealthDataProvider {
 
   @override
   Future<List<HealthSample>> fetch(DateTimeRange range) async {
-    // TODO: fetch data from Apple Health
+    final db = DBService();
+    await db.insertWeightSample(
+      date: range.end,
+      value: 70.0,
+      source: 'apple',
+    );
+    await db.insertEnergySample(
+      date: range.end,
+      kcalIn: 2000,
+      kcalOut: 2500,
+      source: 'apple',
+    );
     return [];
   }
 

--- a/lib/services/health/fitbit_provider.dart
+++ b/lib/services/health/fitbit_provider.dart
@@ -5,6 +5,7 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_appauth/flutter_appauth.dart';
 
 import 'health_data_provider.dart';
+import '../db_service.dart';
 
 class FitbitProvider implements HealthDataProvider {
   final FlutterSecureStorage _storage = const FlutterSecureStorage();
@@ -54,7 +55,18 @@ class FitbitProvider implements HealthDataProvider {
 
   @override
   Future<List<HealthSample>> fetch(DateTimeRange range) async {
-    // TODO: use Fitbitter to fetch data with [accessToken]
+    final db = DBService();
+    await db.insertWeightSample(
+      date: range.end,
+      value: 72.0,
+      source: 'fitbit',
+    );
+    await db.insertEnergySample(
+      date: range.end,
+      kcalIn: 2100,
+      kcalOut: 2400,
+      source: 'fitbit',
+    );
     return [];
   }
 

--- a/lib/services/health/google_fit_provider.dart
+++ b/lib/services/health/google_fit_provider.dart
@@ -3,6 +3,7 @@ import 'package:health/health.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
 import 'health_data_provider.dart';
+import '../db_service.dart';
 
 class GoogleFitProvider implements HealthDataProvider {
   final HealthFactory _health = HealthFactory(useHealthConnectIfAvailable: true);
@@ -27,7 +28,18 @@ class GoogleFitProvider implements HealthDataProvider {
 
   @override
   Future<List<HealthSample>> fetch(DateTimeRange range) async {
-    // TODO: fetch data from Google Fit
+    final db = DBService();
+    await db.insertWeightSample(
+      date: range.end,
+      value: 75.0,
+      source: 'google',
+    );
+    await db.insertEnergySample(
+      date: range.end,
+      kcalIn: 2200,
+      kcalOut: 2600,
+      source: 'google',
+    );
     return [];
   }
 

--- a/lib/services/health/health_service.dart
+++ b/lib/services/health/health_service.dart
@@ -1,4 +1,29 @@
+import 'dart:io';
 import 'package:flutter/material.dart';
+import 'package:workmanager/workmanager.dart';
+import 'package:background_fetch/background_fetch.dart';
+
+void _workmanagerCallbackDispatcher() {
+  Workmanager().executeTask((task, inputData) async {
+    final service = HealthService();
+    service.registerAvailableProviders();
+    await service.sync(DateTimeRange(
+      start: DateTime.now().subtract(const Duration(hours: 24)),
+      end: DateTime.now(),
+    ));
+    return Future.value(true);
+  });
+}
+
+void _backgroundFetchTask(String taskId) async {
+  final service = HealthService();
+  service.registerAvailableProviders();
+  await service.sync(DateTimeRange(
+    start: DateTime.now().subtract(const Duration(hours: 24)),
+    end: DateTime.now(),
+  ));
+  BackgroundFetch.finish(taskId);
+}
 
 import 'apple_health_provider.dart';
 import 'fitbit_provider.dart';
@@ -15,6 +40,26 @@ class HealthService {
     _providers.add(AppleHealthProvider());
     _providers.add(GoogleFitProvider());
     _providers.add(FitbitProvider());
+  }
+
+  void registerBackgroundSync() {
+    if (Platform.isAndroid) {
+      Workmanager().initialize(_workmanagerCallbackDispatcher);
+      Workmanager().registerPeriodicTask(
+        'healthSync',
+        'healthSync',
+        frequency: const Duration(hours: 6),
+      );
+    } else if (Platform.isIOS) {
+      BackgroundFetch.configure(
+        const BackgroundFetchConfig(
+          minimumFetchInterval: 360,
+          enableHeadless: true,
+          startOnBoot: true,
+        ),
+        _backgroundFetchTask,
+      );
+    }
   }
 
   Future<void> sync(DateTimeRange range) async {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -66,6 +66,7 @@ dependencies:
   dio: ^5.4.0
   permission_handler: ^11.3.0
   workmanager: ^0.5.0              # background sync
+  background_fetch: ^1.2.0
 
 
 dev_dependencies:


### PR DESCRIPTION
## Summary
- add background_fetch dependency
- create new tables and migrations for weight and energy samples
- schedule background health sync
- stub out provider fetch methods to store sample health data
- expose DB helpers for new tables

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851a73eb7048323a054ef3459878716