### PR TITLE
Make UserStatsScreen modular

### DIFF
--- a/lib/screens/user_stats_screen.dart
+++ b/lib/screens/user_stats_screen.dart
@@ -7,9 +7,36 @@ import 'package:lift_league/widgets/checkin_graph.dart';
 import 'package:lift_league/widgets/consistency_meter.dart';
 import 'package:lift_league/widgets/efficiency_meter.dart';
 import 'package:lift_league/widgets/momentum_meter.dart';
+import 'package:lift_league/widgets/stats/calories_chart.dart';
+import 'package:lift_league/widgets/stats/body_weight_chart.dart';
+import 'package:lift_league/widgets/stats/widget_picker_bottom_sheet.dart';
 import 'package:lift_league/services/db_service.dart';
 
-class UserStatsScreen extends StatelessWidget {
+const Map<String, String> _widgetNames = {
+  'lifetimeStats': 'Lifetime Stats',
+  'consistencyMeter': 'Consistency',
+  'efficiencyMeter': 'Efficiency',
+  'momentumMeter': 'Momentum',
+  'caloriesChart': 'Calories Chart',
+  'bodyWeightChart': 'Body Weight Chart',
+  'checkInGraph': 'Check-In Graph',
+  'bigThreePrs': 'Big Three PRs',
+  'badgeDisplay': 'Badges',
+};
+
+const List<String> _defaultLayout = [
+  'lifetimeStats',
+  'consistencyMeter',
+  'efficiencyMeter',
+  'momentumMeter',
+  'caloriesChart',
+  'bodyWeightChart',
+  'checkInGraph',
+  'bigThreePrs',
+  'badgeDisplay',
+];
+
+class UserStatsScreen extends StatefulWidget {
   final String userId;
   final String? blockId;
   final bool showCheckInGraph;
@@ -21,14 +48,28 @@ class UserStatsScreen extends StatelessWidget {
     this.showCheckInGraph = true,
   });
 
+  @override
+  State<UserStatsScreen> createState() => _UserStatsScreenState();
+}
+
+class _UserStatsScreenState extends State<UserStatsScreen> {
+  late Future<Map<String, dynamic>?> _userFuture;
+  late Future<List<String>> _layoutFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _userFuture = _fetchUserData();
+    _layoutFuture = _fetchLayout();
+  }
   Future<Map<String, dynamic>?> _fetchUserData() async {
     final doc =
-        await FirebaseFirestore.instance.collection('users').doc(userId).get();
+        await FirebaseFirestore.instance.collection('users').doc(widget.userId).get();
     final data = doc.data();
 
-    if (blockId == null) {
+    if (widget.blockId == null) {
       String? activeId = data?['activeBlockInstanceId']?.toString();
-      activeId ??= await DBService().getActiveBlockInstanceId(userId);
+      activeId ??= await DBService().getActiveBlockInstanceId(widget.userId);
       if (activeId != null) {
         data?['activeBlockInstanceId'] = activeId;
       }
@@ -37,90 +78,178 @@ class UserStatsScreen extends StatelessWidget {
     return data;
   }
 
+  Future<List<String>> _fetchLayout() async {
+    final doc = await FirebaseFirestore.instance
+        .doc('users/${widget.userId}/preferences')
+        .get();
+    final data = doc.data();
+    if (data != null && data['statsLayout'] is List) {
+      return List<String>.from(data['statsLayout']);
+    }
+    return _defaultLayout;
+  }
+
+  List<Widget> _buildWidgets(List<String> layout, Map<String, dynamic> userData) {
+    final activeBlockId =
+        widget.blockId ?? userData['activeBlockInstanceId']?.toString();
+    final widgets = <Widget>[];
+    bool shownNoBlockMsg = false;
+    for (final id in layout) {
+      switch (id) {
+        case 'lifetimeStats':
+          widgets.add(LifetimeStats(userId: widget.userId));
+          widgets.add(const SizedBox(height: 20));
+          break;
+        case 'consistencyMeter':
+          if (activeBlockId == null) {
+            if (!shownNoBlockMsg) {
+              widgets.add(
+                  const Text('Start a training block to track your stats!'));
+              widgets.add(const SizedBox(height: 20));
+              shownNoBlockMsg = true;
+            }
+          } else {
+            widgets.add(const Text('Consistency',
+                style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold)));
+            widgets.add(const SizedBox(height: 8));
+            widgets.add(ConsistencyMeter(
+                userId: widget.userId,
+                blockId: int.tryParse(activeBlockId) ?? 0));
+            widgets.add(const SizedBox(height: 20));
+          }
+          break;
+        case 'efficiencyMeter':
+          if (activeBlockId != null) {
+            widgets.add(const Text('Efficiency',
+                style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold)));
+            widgets.add(const SizedBox(height: 8));
+            widgets.add(EfficiencyMeter(
+                userId: widget.userId, blockId: activeBlockId));
+            widgets.add(const SizedBox(height: 20));
+          }
+          break;
+        case 'momentumMeter':
+          if (activeBlockId != null) {
+            widgets.add(const Text('Momentum',
+                style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold)));
+            widgets.add(const SizedBox(height: 8));
+            widgets.add(MomentumMeter(userId: widget.userId));
+            widgets.add(const SizedBox(height: 20));
+          }
+          break;
+        case 'caloriesChart':
+          widgets.add(CaloriesChart(userId: widget.userId));
+          widgets.add(const SizedBox(height: 20));
+          break;
+        case 'bodyWeightChart':
+          widgets.add(BodyWeightChart(userId: widget.userId));
+          widgets.add(const SizedBox(height: 20));
+          break;
+        case 'checkInGraph':
+          if (widget.showCheckInGraph) {
+            widgets.add(CheckInGraph(userId: widget.userId));
+            widgets.add(const SizedBox(height: 20));
+          }
+          break;
+        case 'bigThreePrs':
+          widgets.add(BigThreePRs(userId: widget.userId));
+          widgets.add(const SizedBox(height: 20));
+          break;
+        case 'badgeDisplay':
+          widgets.add(BadgeDisplay(userId: widget.userId));
+          widgets.add(const SizedBox(height: 20));
+          break;
+      }
+    }
+    if (widgets.isNotEmpty) {
+      widgets.removeLast();
+    }
+    return widgets;
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Stats')),
+      appBar: AppBar(
+        title: const Text('Stats'),
+        actions: [
+          FutureBuilder<List<String>>(
+            future: _layoutFuture,
+            builder: (context, snapshot) {
+              if (!snapshot.hasData) return const SizedBox.shrink();
+              return IconButton(
+                icon: const Icon(Icons.tune),
+                onPressed: () async {
+                  final newLayout = await showModalBottomSheet<List<String>>(
+                    context: context,
+                    isScrollControlled: true,
+                    builder: (_) => WidgetPickerBottomSheet(
+                      userId: widget.userId,
+                      currentLayout: snapshot.data!,
+                      availableWidgets: _widgetNames,
+                    ),
+                  );
+                  if (newLayout != null) {
+                    setState(() {
+                      _layoutFuture = Future.value(newLayout);
+                    });
+                  }
+                },
+              );
+            },
+          ),
+        ],
+      ),
       body: FutureBuilder<Map<String, dynamic>?>(
-        future: _fetchUserData(),
+        future: _userFuture,
         builder: (context, snapshot) {
           if (!snapshot.hasData) {
             return const Center(child: CircularProgressIndicator());
           }
 
           final userData = snapshot.data!;
-          final activeBlockId =
-              blockId ?? userData['activeBlockInstanceId']?.toString();
           final displayName = userData['displayName'] ?? 'Unknown User';
           final title = userData['title'] ?? '';
 
-          return SingleChildScrollView(
-            padding: const EdgeInsets.all(16),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                // 👇 New section with name + title
-                Column(
+          return FutureBuilder<List<String>>(
+            future: _layoutFuture,
+            builder: (context, layoutSnap) {
+              if (!layoutSnap.hasData) {
+                return const Center(child: CircularProgressIndicator());
+              }
+              final layout = layoutSnap.data!;
+              return SingleChildScrollView(
+                padding: const EdgeInsets.all(16),
+                child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    Text(
-                      displayName,
-                        style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold, color: Color(0xFFFC3B3D),
-                      ),
-                    ),
-                    if (title.isNotEmpty)
-                      Text(
-                        title,
-                        style: const TextStyle(
-                          fontSize: 18,
-                          fontStyle: FontStyle.italic,
-                          color: Colors.grey,
+                    Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          displayName,
+                          style: const TextStyle(
+                              fontSize: 24,
+                              fontWeight: FontWeight.bold,
+                              color: Color(0xFFFC3B3D)),
                         ),
-                      ),
+                        if (title.isNotEmpty)
+                          Text(
+                            title,
+                            style: const TextStyle(
+                              fontSize: 18,
+                              fontStyle: FontStyle.italic,
+                              color: Colors.grey,
+                            ),
+                          ),
+                      ],
+                    ),
+                    const SizedBox(height: 20),
+                    ..._buildWidgets(layout, userData),
                   ],
                 ),
-
-                // Existing sections
-                LifetimeStats(userId: userId),
-                const SizedBox(height: 20),
-                if (activeBlockId == null) ...[
-                  const Text('Start a training block to track your stats!'),
-                  const SizedBox(height: 20),
-                ] else ...[
-                  const Text(
-                    'Consistency',
-                    style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
-                  ),
-                  const SizedBox(height: 8),
-                  ConsistencyMeter(userId: userId,
-                    blockId: int.tryParse(activeBlockId) ?? 0,
-                  ),
-                  const SizedBox(height: 20),
-                  const Text(
-                    'Efficiency',
-                    style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
-                  ),
-                  const SizedBox(height: 8),
-                  EfficiencyMeter(userId: userId, blockId: activeBlockId),
-                  const SizedBox(height: 20),
-                  const Text(
-                    'Momentum',
-                    style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
-                  ),
-                  const SizedBox(height: 8),
-                  MomentumMeter(userId: userId),
-                  const SizedBox(height: 20),
-                ],
-                if (showCheckInGraph) ...[
-                  CheckInGraph(userId: userId),
-                  const SizedBox(height: 20),
-                ],
-                BigThreePRs(userId: userId),
-                const SizedBox(height: 20),
-                BadgeDisplay(userId: userId),
-                const SizedBox(height: 20),
-              ],
-            ),
+              );
+            },
           );
         },
       ),

--- a/lib/widgets/stats/body_weight_chart.dart
+++ b/lib/widgets/stats/body_weight_chart.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+
+class BodyWeightChart extends StatelessWidget {
+  final String userId;
+  const BodyWeightChart({super.key, required this.userId});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: 150,
+      color: Colors.lightBlueAccent.withOpacity(0.2),
+      alignment: Alignment.center,
+      child: const Text('Body Weight Chart'),
+    );
+  }
+}

--- a/lib/widgets/stats/calories_chart.dart
+++ b/lib/widgets/stats/calories_chart.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+
+class CaloriesChart extends StatelessWidget {
+  final String userId;
+  const CaloriesChart({super.key, required this.userId});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: 150,
+      color: Colors.orangeAccent.withOpacity(0.2),
+      alignment: Alignment.center,
+      child: const Text('Calories Chart'),
+    );
+  }
+}

--- a/lib/widgets/stats/widget_picker_bottom_sheet.dart
+++ b/lib/widgets/stats/widget_picker_bottom_sheet.dart
@@ -1,0 +1,95 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+
+class WidgetPickerBottomSheet extends StatefulWidget {
+  final String userId;
+  final List<String> currentLayout;
+  final Map<String, String> availableWidgets;
+
+  const WidgetPickerBottomSheet({
+    super.key,
+    required this.userId,
+    required this.currentLayout,
+    required this.availableWidgets,
+  });
+
+  @override
+  State<WidgetPickerBottomSheet> createState() => _WidgetPickerBottomSheetState();
+}
+
+class _PickerItem {
+  String id;
+  bool enabled;
+  _PickerItem({required this.id, required this.enabled});
+}
+
+class _WidgetPickerBottomSheetState extends State<WidgetPickerBottomSheet> {
+  late List<_PickerItem> _items;
+
+  @override
+  void initState() {
+    super.initState();
+    final enabledSet = widget.currentLayout.toSet();
+    final remaining = widget.availableWidgets.keys
+        .where((id) => !enabledSet.contains(id))
+        .toList();
+    _items = [
+      ...widget.currentLayout.map((id) => _PickerItem(id: id, enabled: true)),
+      ...remaining.map((id) => _PickerItem(id: id, enabled: false)),
+    ];
+  }
+
+  Future<void> _save() async {
+    final layout = _items.where((e) => e.enabled).map((e) => e.id).toList();
+    await FirebaseFirestore.instance
+        .doc('users/${widget.userId}/preferences')
+        .set({'statsLayout': layout}, SetOptions(merge: true));
+    if (mounted) Navigator.pop(context, layout);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Expanded(
+            child: ReorderableListView(
+              onReorder: (oldIndex, newIndex) {
+                setState(() {
+                  if (newIndex > oldIndex) newIndex--;
+                  final item = _items.removeAt(oldIndex);
+                  _items.insert(newIndex, item);
+                });
+              },
+              children: [
+                for (final item in _items)
+                  ListTile(
+                    key: ValueKey(item.id),
+                    leading: const Icon(Icons.drag_handle),
+                    title: Text(widget.availableWidgets[item.id] ?? item.id),
+                    trailing: Switch(
+                      value: item.enabled,
+                      onChanged: (val) {
+                        setState(() {
+                          item.enabled = val;
+                        });
+                      },
+                    ),
+                  ),
+              ],
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: ElevatedButton(
+              onPressed: _save,
+              child: const Text('Save'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- add placeholder calories & body weight charts
- create stats widget picker with reorderable list
- allow saving layout to Firestore
- fetch statsLayout from user preferences and build widgets dynamically
- add tune icon to open widget picker

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851a99ebbec83238271f85722d1677f