### PR TITLE
Fix HealthService call and skip fetch when disconnected

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -85,7 +85,7 @@ void main() async {
     options: DefaultFirebaseOptions.currentPlatform,
   );
 
-  HealthService().registerBackgroundSync();
+  HealthService.registerBackgroundSync();
 
   analytics = FirebaseAnalytics.instance;
 

--- a/lib/services/health/apple_health_provider.dart
+++ b/lib/services/health/apple_health_provider.dart
@@ -28,6 +28,7 @@ class AppleHealthProvider implements HealthDataProvider {
 
   @override
   Future<List<HealthSample>> fetch(DateTimeRange range) async {
+    if (!await isConnected()) return [];
     final db = DBService();
     await db.insertWeightSample(
       date: range.end,

--- a/lib/services/health/fitbit_provider.dart
+++ b/lib/services/health/fitbit_provider.dart
@@ -55,6 +55,7 @@ class FitbitProvider implements HealthDataProvider {
 
   @override
   Future<List<HealthSample>> fetch(DateTimeRange range) async {
+    if (!await isConnected()) return [];
     final db = DBService();
     await db.insertWeightSample(
       date: range.end,

--- a/lib/services/health/google_fit_provider.dart
+++ b/lib/services/health/google_fit_provider.dart
@@ -28,6 +28,7 @@ class GoogleFitProvider implements HealthDataProvider {
 
   @override
   Future<List<HealthSample>> fetch(DateTimeRange range) async {
+    if (!await isConnected()) return [];
     final db = DBService();
     await db.insertWeightSample(
       date: range.end,


### PR DESCRIPTION
## Summary
- call `HealthService.registerBackgroundSync()` as static
- skip health data fetches when provider isn't connected

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851af14047c832384d733af7f90ce14