### PR TITLE
Add Privacy Policy & Terms pages

### DIFF
--- a/lib/web_tools/poss_drawer.dart
+++ b/lib/web_tools/poss_drawer.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 
 import 'about_screen.dart';
+import 'privacy_policy_screen.dart';
 import 'poss_block_builder.dart';
+import 'terms_of_service_screen.dart';
 
 class POSSDrawer extends StatelessWidget {
   final VoidCallback? onHome;
@@ -48,6 +50,28 @@ class POSSDrawer extends StatelessWidget {
               Navigator.push(
                 context,
                 MaterialPageRoute(builder: (_) => const AboutScreen()),
+              );
+            },
+          ),
+          ListTile(
+            leading: const Icon(Icons.privacy_tip),
+            title: const Text('Privacy Policy'),
+            onTap: () {
+              Navigator.pop(context);
+              Navigator.push(
+                context,
+                MaterialPageRoute(builder: (_) => const PrivacyPolicyScreen()),
+              );
+            },
+          ),
+          ListTile(
+            leading: const Icon(Icons.description),
+            title: const Text('Terms of Service'),
+            onTap: () {
+              Navigator.pop(context);
+              Navigator.push(
+                context,
+                MaterialPageRoute(builder: (_) => const TermsOfServiceScreen()),
               );
             },
           ),

--- a/lib/web_tools/poss_home_page.dart
+++ b/lib/web_tools/poss_home_page.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'about_screen.dart';
 import 'custom_blocks_screen.dart';
 import 'poss_block_builder.dart';
+import 'privacy_policy_screen.dart';
+import 'terms_of_service_screen.dart';
 import '../services/db_service.dart';
 import '../services/promo_popup_service.dart';
 
@@ -108,6 +110,28 @@ class _POSSHomePageState extends State<POSSHomePage> {
                   Navigator.push(
                     context,
                     MaterialPageRoute(builder: (_) => const AboutScreen()),
+                  );
+                },
+              ),
+              ListTile(
+                leading: const Icon(Icons.privacy_tip),
+                title: const Text('Privacy Policy'),
+                onTap: () {
+                  Navigator.pop(context);
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(builder: (_) => const PrivacyPolicyScreen()),
+                  );
+                },
+              ),
+              ListTile(
+                leading: const Icon(Icons.description),
+                title: const Text('Terms of Service'),
+                onTap: () {
+                  Navigator.pop(context);
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(builder: (_) => const TermsOfServiceScreen()),
                   );
                 },
               ),

--- a/lib/web_tools/privacy_policy_screen.dart
+++ b/lib/web_tools/privacy_policy_screen.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'poss_drawer.dart';
+
+Color? _lightGrey = Colors.grey[400];
+
+class PrivacyPolicyScreen extends StatelessWidget {
+  const PrivacyPolicyScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return DefaultTextStyle(
+      style: TextStyle(color: _lightGrey),
+      child: Scaffold(
+        appBar: AppBar(
+          foregroundColor: _lightGrey,
+          title: const Text('Privacy Policy'),
+        ),
+        drawer: const POSSDrawer(),
+        body: const Padding(
+          padding: EdgeInsets.all(16),
+          child: SingleChildScrollView(
+            child: Text(
+              'Privacy Policy content goes here.',
+              softWrap: true,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/web_tools/terms_of_service_screen.dart
+++ b/lib/web_tools/terms_of_service_screen.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'poss_drawer.dart';
+
+Color? _lightGrey = Colors.grey[400];
+
+class TermsOfServiceScreen extends StatelessWidget {
+  const TermsOfServiceScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return DefaultTextStyle(
+      style: TextStyle(color: _lightGrey),
+      child: Scaffold(
+        appBar: AppBar(
+          foregroundColor: _lightGrey,
+          title: const Text('Terms of Service'),
+        ),
+        drawer: const POSSDrawer(),
+        body: const Padding(
+          padding: EdgeInsets.all(16),
+          child: SingleChildScrollView(
+            child: Text(
+              'Terms of Service content goes here.',
+              softWrap: true,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add PrivacyPolicyScreen and TermsOfServiceScreen to `web_tools`
- show new pages in the nav drawer

## Testing
- `dart format lib/web_tools/privacy_policy_screen.dart lib/web_tools/terms_of_service_screen.dart lib/web_tools/poss_drawer.dart lib/web_tools/poss_home_page.dart` *(fails: `dart` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851d3e8ce808323a2eab8307d74562e