### PR TITLE
Integrate Fitbit auth and metrics

### DIFF
--- a/lib/services/db_service.dart
+++ b/lib/services/db_service.dart
@@ -33,7 +33,7 @@ class DBService {
 
     return await openDatabase(
       path,
-      version: 14,
+      version: 15,
       onCreate: (db, version) async {
         await db.execute("PRAGMA foreign_keys = ON;");
 
@@ -96,6 +96,8 @@ class DBService {
               id INTEGER PRIMARY KEY AUTOINCREMENT,
               date TEXT,
               value REAL,
+              bmi REAL,
+              bodyFat REAL,
               source TEXT
             )
           ''');
@@ -108,6 +110,10 @@ class DBService {
               source TEXT
             )
           ''');
+        }
+        if (oldVersion < 15) {
+          await db.execute("ALTER TABLE health_weight_samples ADD COLUMN bmi REAL;");
+          await db.execute("ALTER TABLE health_weight_samples ADD COLUMN bodyFat REAL;");
         }
       },
     );
@@ -291,6 +297,8 @@ class DBService {
         id INTEGER PRIMARY KEY AUTOINCREMENT,
         date TEXT,
         value REAL,
+        bmi REAL,
+        bodyFat REAL,
         source TEXT
       )
     ''');
@@ -2348,13 +2356,17 @@ class DBService {
 
   Future<void> insertWeightSample({
     required DateTime date,
-    required double value,
+    double? value,
+    double? bmi,
+    double? bodyFat,
     required String source,
   }) async {
     final db = await database;
     await db.insert('health_weight_samples', {
       'date': date.toIso8601String(),
       'value': value,
+      'bmi': bmi,
+      'bodyFat': bodyFat,
       'source': source,
     });
   }

--- a/lib/services/health/fitbit_credentials.dart
+++ b/lib/services/health/fitbit_credentials.dart
@@ -1,0 +1,3 @@
+const String fitbitClientId = String.fromEnvironment('FITBIT_CLIENT_ID');
+const String fitbitClientSecret = String.fromEnvironment('FITBIT_CLIENT_SECRET');
+const String fitbitRedirectUri = String.fromEnvironment('FITBIT_REDIRECT_URI');


### PR DESCRIPTION
## Summary
- add environment-based Fitbit credentials
- update Fitbit provider to pull weight/BMI/body fat data
- extend health weight table for BMI and body fat

## Testing
- `dart format -o none --set-exit-if-changed lib/services/health/fitbit_provider.dart` *(fails: dart not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851f856f8ac8323b897ed34eae3304d