### PR TITLE
Add Fitbit check-in prefill

### DIFF
--- a/lib/screens/add_check_in_screen.dart
+++ b/lib/screens/add_check_in_screen.dart
@@ -9,6 +9,7 @@ import 'package:flutter_image_compress/flutter_image_compress.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:image_cropper/image_cropper.dart';
 import 'dart:async';
+import '../services/db_service.dart';
 
 class AddCheckInScreen extends StatefulWidget {
   const AddCheckInScreen({super.key});
@@ -25,6 +26,26 @@ class _AddCheckInScreenState extends State<AddCheckInScreen> {
   String? _selectedBlock;
   bool _isUploading = false;
   List<File> _imageFiles = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _prefillFromFitbit();
+  }
+
+  Future<void> _prefillFromFitbit() async {
+    final sample = await DBService()
+        .getLatestWeightSampleForDay(DateTime.now(), source: 'fitbit');
+    if (sample == null) return;
+    setState(() {
+      final weight = sample['value'] as num?;
+      final bodyFat = sample['bodyFat'] as num?;
+      final bmi = sample['bmi'] as num?;
+      if (weight != null) _weightController.text = weight.toString();
+      if (bodyFat != null) _bodyFatController.text = bodyFat.toString();
+      if (bmi != null) _bmiController.text = bmi.toString();
+    });
+  }
 
 
   Future<List<File>> _pickAndCropImages() async {

--- a/lib/services/db_service.dart
+++ b/lib/services/db_service.dart
@@ -2371,6 +2371,29 @@ class DBService {
     });
   }
 
+  Future<Map<String, dynamic>?> getLatestWeightSampleForDay(
+    DateTime day, {
+    String source = 'fitbit',
+  }) async {
+    final db = await database;
+    final start = DateTime(day.year, day.month, day.day);
+    final end = start.add(const Duration(days: 1));
+    final rows = await db.query(
+      'health_weight_samples',
+      columns: ['value', 'bmi', 'bodyFat'],
+      where: 'date >= ? AND date < ? AND source = ?',
+      whereArgs: [
+        start.toIso8601String(),
+        end.toIso8601String(),
+        source,
+      ],
+      orderBy: 'date DESC',
+      limit: 1,
+    );
+    if (rows.isEmpty) return null;
+    return rows.first;
+  }
+
   Future<void> insertEnergySample({
     required DateTime date,
     required double kcalIn,


### PR DESCRIPTION
## Summary
- add DB helper to fetch latest weight sample by day
- auto-prefill check-in metrics from Fitbit data

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68520865b6dc83238459d200831a8dfb