### PR TITLE
Add web stubs for health providers

### DIFF
--- a/lib/screens/settings/connected_apps_screen.dart
+++ b/lib/screens/settings/connected_apps_screen.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
-import '../../services/health/apple_health_provider.dart';
-import '../../services/health/google_fit_provider.dart';
+import '../../services/health/apple_health_provider_stub.dart'
+    if (dart.library.io) '../../services/health/apple_health_provider.dart';
+import '../../services/health/google_fit_provider_stub.dart'
+    if (dart.library.io) '../../services/health/google_fit_provider.dart';
 import '../../services/health/fitbit_provider.dart';
 
 class ConnectedAppsScreen extends StatefulWidget {

--- a/lib/services/health/apple_health_provider_stub.dart
+++ b/lib/services/health/apple_health_provider_stub.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+import 'package:health/health.dart';
+
+import 'health_data_provider.dart';
+
+/// Stub implementation for platforms without Health integration.
+class AppleHealthProvider implements HealthDataProvider {
+  static const connectedKey = 'appleHealthConnected';
+
+  Future<bool> requestAuthorization() async => false;
+
+  Future<bool> isConnected() async => false;
+
+  Future<void> disconnect() async {}
+
+  @override
+  Future<List<HealthDataPoint>> fetch(DateTimeRange range) async => [];
+
+  @override
+  Stream<HealthDataPoint> watchChanges() => const Stream.empty();
+}

--- a/lib/services/health/google_fit_provider_stub.dart
+++ b/lib/services/health/google_fit_provider_stub.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+import 'package:health/health.dart';
+
+import 'health_data_provider.dart';
+
+/// Stub implementation for platforms without Google Fit.
+class GoogleFitProvider implements HealthDataProvider {
+  static const connectedKey = 'googleFitConnected';
+
+  Future<bool> requestAuthorization() async => false;
+
+  Future<bool> isConnected() async => false;
+
+  Future<void> disconnect() async {}
+
+  @override
+  Future<List<HealthDataPoint>> fetch(DateTimeRange range) async => [];
+
+  @override
+  Stream<HealthDataPoint> watchChanges() => const Stream.empty();
+}

--- a/lib/services/health/health_service.dart
+++ b/lib/services/health/health_service.dart
@@ -3,9 +3,11 @@ import 'package:flutter/material.dart';
 import 'package:workmanager/workmanager.dart';
 import 'package:background_fetch/background_fetch.dart';
 
-import 'apple_health_provider.dart';
+import 'apple_health_provider_stub.dart'
+    if (dart.library.io) 'apple_health_provider.dart';
 import 'fitbit_provider.dart';
-import 'google_fit_provider.dart';
+import 'google_fit_provider_stub.dart'
+    if (dart.library.io) 'google_fit_provider.dart';
 import 'health_data_provider.dart';
 
 /// Top-level background sync task for Workmanager (Android)


### PR DESCRIPTION
## Summary
- add stub implementations for Apple Health and Google Fit
- switch to conditional imports so stubs are used on non-IO platforms

## Testing
- `flutter format lib/services/health/apple_health_provider_stub.dart lib/services/health/google_fit_provider_stub.dart lib/screens/settings/connected_apps_screen.dart lib/services/health/health_service.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68520e19b5148323913a2c0866a175a6