### PR TITLE
Add health stubs for web builds

### DIFF
--- a/lib/services/health/apple_health_provider_stub.dart
+++ b/lib/services/health/apple_health_provider_stub.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:health/health.dart';
+import 'health_stub.dart'
+    if (dart.library.io) 'package:health/health.dart';
 
 import 'health_data_provider.dart';
 

--- a/lib/services/health/fitbit_provider.dart
+++ b/lib/services/health/fitbit_provider.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:health/health.dart';
+import 'health_stub.dart'
+    if (dart.library.io) 'package:health/health.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_appauth/flutter_appauth.dart';

--- a/lib/services/health/google_fit_provider_stub.dart
+++ b/lib/services/health/google_fit_provider_stub.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:health/health.dart';
+import 'health_stub.dart'
+    if (dart.library.io) 'package:health/health.dart';
 
 import 'health_data_provider.dart';
 

--- a/lib/services/health/health_data_provider.dart
+++ b/lib/services/health/health_data_provider.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:health/health.dart';
+import 'health_stub.dart'
+    if (dart.library.io) 'package:health/health.dart';
 
 abstract class HealthDataProvider {
   Future<List<HealthDataPoint>> fetch(DateTimeRange range);

--- a/lib/services/health/health_stub.dart
+++ b/lib/services/health/health_stub.dart
@@ -1,0 +1,12 @@
+class HealthDataPoint {
+  const HealthDataPoint();
+}
+
+enum HealthDataType { STEPS, ACTIVE_ENERGY_BURNED }
+
+class HealthFactory {
+  final bool useHealthConnectIfAvailable;
+  const HealthFactory({this.useHealthConnectIfAvailable = false});
+
+  Future<bool> requestAuthorization(List<HealthDataType> types) async => false;
+}


### PR DESCRIPTION
## Summary
- create `health_stub.dart` with minimal stand‑ins
- use conditional import in `health_data_provider.dart`
- update stub providers and Fitbit provider to conditionally import the stub

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68520ed9724c8323b99fe0d9fb1ef3dc