### PR TITLE
Resume audio after RestTimer chime

### DIFF
--- a/lib/services/rest_timer_service.dart
+++ b/lib/services/rest_timer_service.dart
@@ -18,7 +18,18 @@ class RestTimerService {
   final StreamController<int> _streamController = StreamController<int>.broadcast();
   Stream<int> get stream => _streamController.stream;
 
-  final AudioPlayer _audioPlayer = AudioPlayer();
+  final AudioPlayer _audioPlayer = AudioPlayer()
+    ..audioContext = const AudioContext(
+      android: AudioContextAndroid(
+        usageType: AndroidUsageType.assistanceSonification,
+        contentType: AndroidContentType.sonification,
+        audioFocus: AndroidAudioFocus.gainTransient,
+      ),
+      iOS: AudioContextIOS(
+        category: AVAudioSessionCategory.ambient,
+        options: <AVAudioSessionOptions>{AVAudioSessionOptions.mixWithOthers},
+      ),
+    );
   bool _playSound = true;
 
   Future<void> _loadPrefs() async {


### PR DESCRIPTION
## Summary
- keep external media playing by using a transient audio focus when sounding the timer chime

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852db56e91c832391709fde3ea58468