### PR TITLE
Ensure web tool text uses grey

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -135,7 +135,15 @@ class POSSApp extends StatelessWidget {
     return MaterialApp(
       debugShowCheckedModeBanner: false,
       title: 'POSS Tool',
-      theme: ThemeData.dark(), // or your custom theme
+      theme: ThemeData.dark().copyWith(
+        textTheme: ThemeData.dark().textTheme.apply(
+              bodyColor: Colors.grey[400],
+              displayColor: Colors.grey[400],
+            ),
+        appBarTheme: AppBarTheme(
+          foregroundColor: Colors.grey[400],
+        ),
+      ),
       home: const POSSHomePage(),
       routes: {
         '/poss': (context) => const POSSHomePage(),

--- a/lib/web_tools/merch_screen.dart
+++ b/lib/web_tools/merch_screen.dart
@@ -14,12 +14,19 @@ class MerchScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: const Text('Merch')),
-      body: Center(
-        child: ElevatedButton(
-          onPressed: _openStore,
-          child: const Text('Visit Store'),
+    final Color? lightGrey = Colors.grey[400];
+    return DefaultTextStyle(
+      style: TextStyle(color: lightGrey),
+      child: Scaffold(
+        appBar: AppBar(
+          foregroundColor: lightGrey,
+          title: const Text('Merch'),
+        ),
+        body: Center(
+          child: ElevatedButton(
+            onPressed: _openStore,
+            child: const Text('Visit Store'),
+          ),
         ),
       ),
     );

--- a/lib/web_tools/poss_scoring_tool.dart
+++ b/lib/web_tools/poss_scoring_tool.dart
@@ -5,9 +5,16 @@ class POSSScoringTool extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: const Text('POSS: Lift League Scoring Tool')),
-      body: const Center(child: Text('Coming Soon')),
+    final Color? lightGrey = Colors.grey[400];
+    return DefaultTextStyle(
+      style: TextStyle(color: lightGrey),
+      child: Scaffold(
+        appBar: AppBar(
+          foregroundColor: lightGrey,
+          title: const Text('POSS: Lift League Scoring Tool'),
+        ),
+        body: const Center(child: Text('Coming Soon')),
+      ),
     );
   }
 }


### PR DESCRIPTION
## Summary
- update POSSApp theme to use grey text
- default to grey text in merch and scoring screens

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853152e5c4c8323a3748f3d45eb7f00