### PR TITLE
Add Workout 411 screen

### DIFF
--- a/lib/screens/block_dashboard.dart
+++ b/lib/screens/block_dashboard.dart
@@ -5,6 +5,7 @@ import 'package:lift_league/models/workout.dart';
 import 'package:lift_league/screens/user_dashboard.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:lift_league/screens/leaderboard_screen.dart';
+import 'package:lift_league/screens/workout_411.dart';
 
 
 class BlockDashboard extends StatefulWidget {
@@ -345,12 +346,23 @@ class BlockDashboardState extends State<BlockDashboard> {
               else
                 const SizedBox.shrink(),
 
-              const Text(
-                "The 411",
-                style: TextStyle(
-                  color: Colors.red,
-                  fontSize: 20,
-                  fontStyle: FontStyle.italic,
+              GestureDetector(
+                onTap: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => Workout411Screen(blockName: blockName),
+                    ),
+                  );
+                },
+                child: const Text(
+                  "The 411",
+                  style: TextStyle(
+                    color: Colors.red,
+                    fontSize: 20,
+                    fontStyle: FontStyle.italic,
+                    decoration: TextDecoration.underline,
+                  ),
                 ),
               ),
               const SizedBox(height: 20),

--- a/lib/screens/workout_411.dart
+++ b/lib/screens/workout_411.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+import '../data/workout_metadata.dart';
+
+class Workout411Screen extends StatelessWidget {
+  final String blockName;
+
+  const Workout411Screen({super.key, required this.blockName});
+
+  WorkoutMetadata? _findMetadata() {
+    try {
+      return workoutMetadataList.firstWhere(
+        (m) => m.name.toLowerCase() == blockName.toLowerCase(),
+      );
+    } catch (_) {
+      return null;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final meta = _findMetadata();
+
+    if (meta == null) {
+      return Scaffold(
+        appBar: AppBar(title: const Text('The 411')),
+        body: const Center(child: Text('No info available.')),
+      );
+    }
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('${meta.name} - The 411'),
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            if (meta.mainImage.isNotEmpty)
+              Image.asset(meta.mainImage, fit: BoxFit.cover),
+            const SizedBox(height: 16),
+            Text(
+              meta.description,
+              style: const TextStyle(fontSize: 16),
+            ),
+            const SizedBox(height: 16),
+            Text('Category: ${meta.category}'),
+            Text('Difficulty: ${meta.difficulty}'),
+            Text('Total Weeks: ${meta.totalWeeks}'),
+            Text('Recommended For: ${meta.recommendedExperience}'),
+            const SizedBox(height: 16),
+            if (meta.equipmentNeeded.isNotEmpty) ...[
+              const Text('Equipment Needed:',
+                  style: TextStyle(fontWeight: FontWeight.bold)),
+              const SizedBox(height: 8),
+              ...meta.equipmentNeeded.map((e) => Text('- $e')),
+            ],
+            const SizedBox(height: 16),
+            if (meta.scheduleImage.isNotEmpty)
+              Image.asset(meta.scheduleImage, fit: BoxFit.cover),
+            const SizedBox(height: 16),
+            if (meta.liftList.isNotEmpty) ...[
+              const Text('Lifts Included:',
+                  style: TextStyle(fontWeight: FontWeight.bold)),
+              const SizedBox(height: 8),
+              ...meta.liftList.map((e) => Text('• $e')),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- implement Workout411Screen for showing block metadata
- link from BlockDashboard to Workout411Screen

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68531612fe788323a2b5ccb8a1482579