### PR TITLE
Add dumbbell option to custom block builder

### DIFF
--- a/lib/models/custom_block_models.dart
+++ b/lib/models/custom_block_models.dart
@@ -39,6 +39,7 @@ class CustomBlock {
               repsPerSet: l['repsPerSet'] ?? 0,
               multiplier: (l['multiplier'] as num?)?.toDouble() ?? 1.0,
               isBodyweight: l['isBodyweight'] ?? false,
+              isDumbbellLift: l['isDumbbellLift'] ?? false,
             );
           }).toList(),
         );
@@ -66,11 +67,13 @@ class LiftDraft {
   int repsPerSet;
   double multiplier;
   bool isBodyweight;
+  bool isDumbbellLift;
   LiftDraft({
     required this.name,
     required this.sets,
     required this.repsPerSet,
     required this.multiplier,
     required this.isBodyweight,
+    this.isDumbbellLift = false,
   });
 }

--- a/lib/screens/custom_block_wizard.dart
+++ b/lib/screens/custom_block_wizard.dart
@@ -52,12 +52,13 @@ class _CustomBlockWizardState extends State<CustomBlockWizard> {
                 name: w.name,
                 lifts: w.lifts
                     .map(
-                      (l) => LiftDraft(
+                    (l) => LiftDraft(
                         name: l.name,
                         sets: l.sets,
                         repsPerSet: l.repsPerSet,
                         multiplier: l.multiplier,
                         isBodyweight: l.isBodyweight,
+                        isDumbbellLift: l.isDumbbellLift,
                       ),
                     )
                     .toList(),
@@ -154,6 +155,7 @@ class _CustomBlockWizardState extends State<CustomBlockWizard> {
                   repsPerSet: l.repsPerSet,
                   multiplier: l.multiplier,
                   isBodyweight: l.isBodyweight,
+                  isDumbbellLift: l.isDumbbellLift,
                 ))
             .toList();
         allWorkouts.add(WorkoutDraft(
@@ -225,6 +227,7 @@ class _CustomBlockWizardState extends State<CustomBlockWizard> {
                           'repsPerSet': l.repsPerSet,
                           'multiplier': l.multiplier,
                           'isBodyweight': l.isBodyweight,
+                          'isDumbbellLift': l.isDumbbellLift,
                         })
                     .toList(),
               })

--- a/lib/screens/workout_builder.dart
+++ b/lib/screens/workout_builder.dart
@@ -10,6 +10,7 @@ class WorkoutBuilder extends StatefulWidget {
   final ValueChanged<int> onSelectWorkout;
   final VoidCallback onComplete;
   final bool isLast;
+  final bool showDumbbellOption;
   const WorkoutBuilder({
     super.key,
     required this.workout,
@@ -18,6 +19,7 @@ class WorkoutBuilder extends StatefulWidget {
     required this.onSelectWorkout,
     required this.onComplete,
     this.isLast = false,
+    this.showDumbbellOption = false,
   });
 
   @override
@@ -51,6 +53,7 @@ class _WorkoutBuilderState extends State<WorkoutBuilder> {
     int sets = 3;
     int reps = 10;
     bool isBodyweight = false;
+    bool isDumbbellLift = false;
 
     showModalBottomSheet(
       context: context,
@@ -104,6 +107,13 @@ class _WorkoutBuilderState extends State<WorkoutBuilder> {
                 onChanged: (v) => setState(() => isBodyweight = v ?? false),
                 title: const Text('Body-weight move'),
               ),
+              if (widget.showDumbbellOption)
+                CheckboxListTile(
+                  value: isDumbbellLift,
+                  onChanged: (v) =>
+                      setState(() => isDumbbellLift = v ?? false),
+                  title: const Text('Dumbbell lift'),
+                ),
               const SizedBox(height: 12),
               ElevatedButton(
                 onPressed: () {
@@ -118,10 +128,11 @@ class _WorkoutBuilderState extends State<WorkoutBuilder> {
                     widget.workout.lifts.add(LiftDraft(
                       name: name,
                       sets: sets,
-                      repsPerSet: reps,
-                      multiplier: multiplier,
-                      isBodyweight: isBodyweight,
-                    ));
+                    repsPerSet: reps,
+                    multiplier: multiplier,
+                    isBodyweight: isBodyweight,
+                    isDumbbellLift: isDumbbellLift,
+                  ));
                   });
                   Navigator.pop(context);
                 },

--- a/lib/web_tools/poss_block_builder.dart
+++ b/lib/web_tools/poss_block_builder.dart
@@ -95,6 +95,7 @@ class _POSSBlockBuilderState extends State<POSSBlockBuilder> {
                           'repsPerSet': l.repsPerSet,
                           'multiplier': l.multiplier,
                           'isBodyweight': l.isBodyweight,
+                          'isDumbbellLift': l.isDumbbellLift,
                         })
                     .toList(),
               })
@@ -195,6 +196,7 @@ class _POSSBlockBuilderState extends State<POSSBlockBuilder> {
                   repsPerSet: l.repsPerSet,
                   multiplier: l.multiplier,
                   isBodyweight: l.isBodyweight,
+                  isDumbbellLift: l.isDumbbellLift,
                 ))
             .toList();
         allWorkouts.add(WorkoutDraft(
@@ -351,6 +353,7 @@ class _POSSBlockBuilderState extends State<POSSBlockBuilder> {
                         onSelectWorkout: (i) =>
                             setState(() => _workoutIndex = i),
                         isLast: _workoutIndex == workouts.length - 1,
+                        showDumbbellOption: true,
                         onComplete: () async {
                           if (_workoutIndex < workouts.length - 1) {
                             setState(() => _workoutIndex++);


### PR DESCRIPTION
## Summary
- support `isDumbbellLift` in `LiftDraft`
- allow WorkoutBuilder to optionally show a dumbbell checkbox
- include dumbbell flag when saving blocks via POSSBlockBuilder
- propagate dumbbell flag through custom block wizard helpers

## Testing
- `dart format -o none --set-exit-if-changed lib` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685328cd32d483239b3ec83edcd9353e