### PR TITLE
Add message encouraging email or sign-in

### DIFF
--- a/lib/web_tools/poss_block_builder.dart
+++ b/lib/web_tools/poss_block_builder.dart
@@ -134,7 +134,13 @@ class _POSSBlockBuilderState extends State<POSSBlockBuilder> {
           title: const Text('Save Block'),
           content: Column(
             mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
             children: [
+              const Text(
+                'To keep this block we need a way to attach it to you.\n'
+                'Sign in with Google or provide an email to link it to your account.',
+              ),
+              const SizedBox(height: 12),
               TextField(
                 controller: emailCtrl,
                 decoration: const InputDecoration(labelText: 'Email'),


### PR DESCRIPTION
## Summary
- show explanation in the web block builder dialog about why email or Google sign‑in is needed

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68532c986a4c8323827e75415f9502e6