### PR TITLE
Fix Gradle namespace for flutter_web_auth

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -36,3 +36,14 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
 
     }
 }
+
+subprojects { project ->
+    afterEvaluate {
+        if (project.name == 'flutter_web_auth' && project.extensions.findByName('android')) {
+            def androidExt = project.extensions.getByName('android')
+            if (!androidExt.hasProperty('namespace')) {
+                androidExt.namespace = 'com.linusu.flutter_web_auth'
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add namespace to flutter_web_auth subproject via Gradle script

## Testing
- `gradle -p android assembleDebug` *(fails: `/workspace/the-lift-league/android/local.properties (No such file or directory)`)*

------
https://chatgpt.com/codex/tasks/task_e_68536eab35248323b6955e34ad740b1e