### PR TITLE
Fix DownloadAppScreen alignment

### DIFF
--- a/lib/web_tools/download_app_screen.dart
+++ b/lib/web_tools/download_app_screen.dart
@@ -27,7 +27,8 @@ class DownloadAppScreen extends StatelessWidget {
         body: Padding(
           padding: const EdgeInsets.all(32),
           child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
+            crossAxisAlignment: CrossAxisAlignment.center,
+            mainAxisAlignment: MainAxisAlignment.start,
             children: [
               const Text(
                 'Download the full Lift League mobile app for the best experience.',


### PR DESCRIPTION
## Summary
- push content to the top of `DownloadAppScreen`

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853740abf408323a7e996c28f495baf