### PR TITLE
Implement unified health sample persistence

### DIFF
--- a/lib/services/health/fitbit_provider.dart
+++ b/lib/services/health/fitbit_provider.dart
@@ -1,12 +1,11 @@
 import 'package:flutter/material.dart';
-import 'health_stub.dart' as health;
+import 'health_samples.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_appauth/flutter_appauth.dart';
 
 import 'fitbit_credentials.dart';
 import 'health_data_provider.dart';
-import '../db_service.dart';
 
 class FitbitProvider implements HealthDataProvider {
   final FlutterSecureStorage _storage = const FlutterSecureStorage();
@@ -56,7 +55,7 @@ class FitbitProvider implements HealthDataProvider {
   }
 
   @override
-  Future<List<health.HealthDataPoint>> fetch(DateTimeRange range) async {
+  Future<List<HealthSample>> fetch(DateTimeRange range) async {
     if (!await isConnected()) return [];
     final token = accessToken ?? await _storage.read(key: tokenKey);
     if (token == null) return [];
@@ -64,7 +63,7 @@ class FitbitProvider implements HealthDataProvider {
     final dio = Dio();
     final headers = {'Authorization': 'Bearer $token'};
     final dateStr = range.end.toIso8601String().split('T').first;
-    final db = DBService();
+    final samples = <HealthSample>[];
 
     try {
       final weightRes = await dio.get(
@@ -74,11 +73,13 @@ class FitbitProvider implements HealthDataProvider {
       final List<dynamic> logs = weightRes.data['weight'] ?? [];
       for (final l in logs) {
         final date = DateTime.parse('${l['date']} ${l['time']}');
-        await db.insertWeightSample(
-          date: date,
-          value: (l['weight'] as num).toDouble(),
-          bmi: (l['bmi'] as num?)?.toDouble(),
-          source: 'fitbit',
+        samples.add(
+          WeightSample(
+            date: date,
+            source: 'fitbit',
+            value: (l['weight'] as num).toDouble(),
+            bmi: (l['bmi'] as num?)?.toDouble(),
+          ),
         );
       }
     } on DioException catch (_) {
@@ -93,19 +94,21 @@ class FitbitProvider implements HealthDataProvider {
       final List<dynamic> logs = fatRes.data['fat'] ?? [];
       for (final l in logs) {
         final date = DateTime.parse('${l['date']} ${l['time']}');
-        await db.insertWeightSample(
-          date: date,
-          bodyFat: (l['fat'] as num).toDouble(),
-          source: 'fitbit',
+        samples.add(
+          WeightSample(
+            date: date,
+            source: 'fitbit',
+            bodyFat: (l['fat'] as num).toDouble(),
+          ),
         );
       }
     } on DioException catch (_) {}
 
-    return [];
+    return samples;
   }
 
   @override
-  Stream<health.HealthDataPoint> watchChanges() {
+  Stream<HealthSample> watchChanges() {
     // Fitbit does not support realtime updates in this stub
     return const Stream.empty();
   }

--- a/lib/services/health/health_data_provider.dart
+++ b/lib/services/health/health_data_provider.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
-import 'health_stub.dart' as health;
+import 'health_samples.dart';
 
 abstract class HealthDataProvider {
-  Future<List<health.HealthDataPoint>> fetch(DateTimeRange range);
-  Stream<health.HealthDataPoint> watchChanges();
+  Future<List<HealthSample>> fetch(DateTimeRange range);
+  Stream<HealthSample> watchChanges();
 }

--- a/lib/services/health/health_samples.dart
+++ b/lib/services/health/health_samples.dart
@@ -1,0 +1,42 @@
+// Models representing generic health samples returned by providers.
+
+enum HealthSampleType { weight, energy }
+
+abstract class HealthSample {
+  final DateTime date;
+  final String source;
+  final HealthSampleType type;
+
+  const HealthSample({
+    required this.date,
+    required this.source,
+    required this.type,
+  });
+}
+
+class WeightSample extends HealthSample {
+  final double? value;
+  final double? bmi;
+  final double? bodyFat;
+
+  WeightSample({
+    required DateTime date,
+    required String source,
+    this.value,
+    this.bmi,
+    this.bodyFat,
+  }) : super(date: date, source: source, type: HealthSampleType.weight);
+}
+
+class EnergySample extends HealthSample {
+  final double kcalIn;
+  final double kcalOut;
+
+  EnergySample({
+    required DateTime date,
+    required String source,
+    required this.kcalIn,
+    required this.kcalOut,
+  }) : super(date: date, source: source, type: HealthSampleType.energy);
+}
+


### PR DESCRIPTION
## Summary
- define `HealthSample`, `WeightSample` and `EnergySample`
- update `HealthDataProvider` interface for generic samples
- refactor `FitbitProvider` to return `WeightSample` instances
- persist provider samples in `HealthService.sync`

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart format` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685391c833e8832397d981a6eab0b33a