### PR TITLE
Set black background for public profile

### DIFF
--- a/lib/screens/public_profile_screen.dart
+++ b/lib/screens/public_profile_screen.dart
@@ -146,12 +146,14 @@ class _PublicProfileScreenState extends State<PublicProfileScreen> {
   Widget build(BuildContext context) {
     if (isLoading) {
       return const Scaffold(
+        backgroundColor: Colors.black,
         body: Center(child: CircularProgressIndicator()),
       );
     }
 
     if (userData == null) {
       return const Scaffold(
+        backgroundColor: Colors.black,
         body: Center(child: Text('User not found.')),
       );
     }
@@ -162,6 +164,7 @@ class _PublicProfileScreenState extends State<PublicProfileScreen> {
     final showCheckInInfo = userData!['showCheckInInfo'] ?? true;
 
     return Scaffold(
+      backgroundColor: Colors.black,
       appBar: AppBar(
         backgroundColor: Colors.black,
         title: _actionLabel != null


### PR DESCRIPTION
## Summary
- make `PublicProfileScreen` use a black background

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68547b50c3cc83239b677610d5d10893