### PR TITLE
Fix Google sign-in for web flow

### DIFF
--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:google_sign_in/google_sign_in.dart';
+import '../services/google_auth_service.dart';
 import 'package:sign_in_with_apple/sign_in_with_apple.dart';
 import 'package:lift_league/data/titles_data.dart';
 import 'user_dashboard.dart';
@@ -88,19 +88,11 @@ class _LoginScreenState extends State<LoginScreen> {
   Future<void> _signInWithGoogle() async {
     setState(() => isLoading = true);
     try {
-      final googleUser = await GoogleSignIn().signIn();
-      if (googleUser == null) {
-
+      final userCred = await GoogleAuthService.signIn();
+      if (userCred == null) {
         setState(() => isLoading = false);
         return;
       }
-      final googleAuth = await googleUser.authentication;
-      final credential = GoogleAuthProvider.credential(
-        accessToken: googleAuth.accessToken,
-        idToken: googleAuth.idToken,
-      );
-      final userCred =
-      await FirebaseAuth.instance.signInWithCredential(credential);
       if (userCred.additionalUserInfo?.isNewUser ?? false) {
         await FirebaseFirestore.instance
             .collection('users')

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -1,11 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:firebase_auth/firebase_auth.dart';
-import 'package:google_sign_in/google_sign_in.dart';
 import 'package:sign_in_with_apple/sign_in_with_apple.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'login_screen.dart';
 import 'package:lift_league/services/title_observer_service.dart';
+import '../services/google_auth_service.dart';
 
 
 class SettingsScreen extends StatefulWidget {
@@ -198,19 +198,14 @@ class _SettingsScreenState extends State<SettingsScreen> {
   }
   Future<void> _linkWithGoogle() async {
     try {
-      final googleUser = await GoogleSignIn().signIn();
-      if (googleUser == null) return;
-      final googleAuth = await googleUser.authentication;
-      final credential = GoogleAuthProvider.credential(
-        accessToken: googleAuth.accessToken,
-        idToken: googleAuth.idToken,
-      );
-      await FirebaseAuth.instance.currentUser?.linkWithCredential(credential);
-      setState(() => googleLinked = true);
-      if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Google account linked')),
-      );
+      final userCred = await GoogleAuthService.link();
+      if (userCred != null) {
+        setState(() => googleLinked = true);
+        if (!mounted) return;
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Google account linked')),
+        );
+      }
     } catch (e) {
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/services/google_auth_service.dart
+++ b/lib/services/google_auth_service.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:google_sign_in/google_sign_in.dart';
+
+class GoogleAuthService {
+  static Future<UserCredential?> signIn() async {
+    final auth = FirebaseAuth.instance;
+    if (kIsWeb) {
+      try {
+        final provider = GoogleAuthProvider();
+        return await auth.signInWithPopup(provider);
+      } catch (_) {
+        return null;
+      }
+    } else {
+      final googleUser = await GoogleSignIn().signIn();
+      if (googleUser == null) return null;
+      final googleAuth = await googleUser.authentication;
+      final credential = GoogleAuthProvider.credential(
+        accessToken: googleAuth.accessToken,
+        idToken: googleAuth.idToken,
+      );
+      return await auth.signInWithCredential(credential);
+    }
+  }
+
+  static Future<UserCredential?> link() async {
+    final auth = FirebaseAuth.instance;
+    if (kIsWeb) {
+      try {
+        final provider = GoogleAuthProvider();
+        return await auth.currentUser?.linkWithPopup(provider);
+      } catch (_) {
+        return null;
+      }
+    } else {
+      final googleUser = await GoogleSignIn().signIn();
+      if (googleUser == null) return null;
+      final googleAuth = await googleUser.authentication;
+      final credential = GoogleAuthProvider.credential(
+        accessToken: googleAuth.accessToken,
+        idToken: googleAuth.idToken,
+      );
+      return await auth.currentUser?.linkWithCredential(credential);
+    }
+  }
+}

--- a/lib/web_tools/poss_block_builder.dart
+++ b/lib/web_tools/poss_block_builder.dart
@@ -5,7 +5,7 @@ import 'package:image_picker/image_picker.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_storage/firebase_storage.dart';
-import 'package:google_sign_in/google_sign_in.dart';
+import '../services/google_auth_service.dart';
 import 'poss_drawer.dart';
 
 import '../models/custom_block_models.dart';
@@ -149,15 +149,10 @@ class _POSSBlockBuilderState extends State<POSSBlockBuilder> {
               ElevatedButton(
                 onPressed: () async {
                   try {
-                    final googleUser = await GoogleSignIn().signIn();
-                    if (googleUser == null) return;
-                    final googleAuth = await googleUser.authentication;
-                    final cred = GoogleAuthProvider.credential(
-                      accessToken: googleAuth.accessToken,
-                      idToken: googleAuth.idToken,
-                    );
-                    await FirebaseAuth.instance.signInWithCredential(cred);
-                    if (context.mounted) Navigator.pop(context);
+                    final cred = await GoogleAuthService.signIn();
+                    if (cred != null && context.mounted) {
+                      Navigator.pop(context);
+                    }
                   } catch (_) {}
                 },
                 child: const Text('Sign in with Google'),


### PR DESCRIPTION
## Summary
- implement `GoogleAuthService` for platform aware Google auth
- switch sign in and linking flows to use the new service
- update Save Block dialog to call the service

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68549b5f8b6c8323b3473ed89f4e45ff