### PR TITLE
Fix keyboard layout issue in POSSBlockBuilder

### DIFF
--- a/lib/web_tools/poss_block_builder.dart
+++ b/lib/web_tools/poss_block_builder.dart
@@ -240,7 +240,7 @@ class _POSSBlockBuilderState extends State<POSSBlockBuilder> {
           title: const Text('Build Training Block'),
         ),
         drawer: const POSSDrawer(),
-        body: Padding(
+        body: SingleChildScrollView(
           padding: EdgeInsets.only(
             bottom: MediaQuery.of(context).viewInsets.bottom,
           ),


### PR DESCRIPTION
## Summary
- wrap `Stepper` with `SingleChildScrollView` so the page scrolls when the keyboard appears

## Testing
- `dart analyze` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854ab21b0288323891b6cadfd3cd84e