### PR TITLE
Enable persistent web auth

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -85,6 +85,10 @@ void main() async {
     options: DefaultFirebaseOptions.currentPlatform,
   );
 
+  if (kIsWeb) {
+    await FirebaseAuth.instance.setPersistence(Persistence.LOCAL);
+  }
+
   HealthService.registerBackgroundSync();
 
   analytics = FirebaseAnalytics.instance;

--- a/lib/web_tools/poss_drawer.dart
+++ b/lib/web_tools/poss_drawer.dart
@@ -5,6 +5,8 @@ import 'privacy_policy_screen.dart';
 import 'poss_block_builder.dart';
 import 'terms_of_service_screen.dart';
 import 'download_app_screen.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import '../screens/login_screen.dart';
 
 class POSSDrawer extends StatelessWidget {
   final VoidCallback? onHome;
@@ -85,6 +87,34 @@ class POSSDrawer extends StatelessWidget {
                 context,
                 MaterialPageRoute(builder: (_) => const DownloadAppScreen()),
               );
+            },
+          ),
+          const Divider(),
+          Builder(
+            builder: (context) {
+              final user = FirebaseAuth.instance.currentUser;
+              if (user == null) {
+                return ListTile(
+                  leading: const Icon(Icons.login),
+                  title: const Text('Sign In'),
+                  onTap: () {
+                    Navigator.pop(context);
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(builder: (_) => const LoginScreen()),
+                    );
+                  },
+                );
+              } else {
+                return ListTile(
+                  leading: const Icon(Icons.logout),
+                  title: const Text('Sign Out'),
+                  onTap: () async {
+                    Navigator.pop(context);
+                    await FirebaseAuth.instance.signOut();
+                  },
+                );
+              }
             },
           ),
         ],

--- a/lib/web_tools/poss_home_page.dart
+++ b/lib/web_tools/poss_home_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import 'about_screen.dart';
 import 'custom_blocks_screen.dart';
 import 'poss_block_builder.dart';
@@ -21,11 +22,15 @@ class POSSHomePage extends StatefulWidget {
 class _POSSHomePageState extends State<POSSHomePage> {
   bool _showGrid = false;
   bool _loading = true;
+  StreamSubscription<User?>? _authSub;
 
   @override
   void initState() {
     super.initState();
     _checkBlocks();
+    _authSub = FirebaseAuth.instance.authStateChanges().listen((_) {
+      _checkBlocks();
+    });
   }
 
   Future<void> _checkBlocks() async {
@@ -169,5 +174,11 @@ class _POSSHomePageState extends State<POSSHomePage> {
         ),
       ),
     );
+  }
+
+  @override
+  void dispose() {
+    _authSub?.cancel();
+    super.dispose();
   }
 }


### PR DESCRIPTION
## Summary
- persist Firebase auth sessions on web
- fetch custom blocks when auth state changes
- allow sign in/out from POSS drawer

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854ae95bb84832384a1d728e7587dd8