### PR TITLE
Add sign-in dialog for web tools

### DIFF
--- a/lib/web_tools/poss_drawer.dart
+++ b/lib/web_tools/poss_drawer.dart
@@ -7,6 +7,7 @@ import 'terms_of_service_screen.dart';
 import 'download_app_screen.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import '../screens/login_screen.dart';
+import 'web_sign_in_dialog.dart';
 
 class POSSDrawer extends StatelessWidget {
   final VoidCallback? onHome;
@@ -23,10 +24,14 @@ class POSSDrawer extends StatelessWidget {
             child: Text('Menu'),
           ),
           ListTile(
-            leading: const Icon(Icons.home),
-            title: const Text('Home'),
-            onTap: () {
+            leading: const Icon(Icons.folder),
+            title: const Text('My Blocks'),
+            onTap: () async {
               Navigator.pop(context);
+              if (FirebaseAuth.instance.currentUser == null) {
+                final signedIn = await showWebSignInDialog(context);
+                if (!signedIn) return;
+              }
               if (onHome != null) {
                 onHome!();
               } else {
@@ -97,12 +102,9 @@ class POSSDrawer extends StatelessWidget {
                 return ListTile(
                   leading: const Icon(Icons.login),
                   title: const Text('Sign In'),
-                  onTap: () {
+                  onTap: () async {
                     Navigator.pop(context);
-                    Navigator.push(
-                      context,
-                      MaterialPageRoute(builder: (_) => const LoginScreen()),
-                    );
+                    await showWebSignInDialog(context);
                   },
                 );
               } else {

--- a/lib/web_tools/poss_home_page.dart
+++ b/lib/web_tools/poss_home_page.dart
@@ -8,6 +8,7 @@ import 'terms_of_service_screen.dart';
 import 'download_app_screen.dart';
 import 'web_custom_block_service.dart';
 import '../services/promo_popup_service.dart';
+import 'web_sign_in_dialog.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
 
 Color? _lightGrey = Colors.grey[400];
@@ -52,6 +53,15 @@ class _POSSHomePageState extends State<POSSHomePage> {
     }
   }
 
+  Future<void> _openMyBlocks() async {
+    if (FirebaseAuth.instance.currentUser == null) {
+      final signedIn = await showWebSignInDialog(context);
+      if (!signedIn) return;
+    }
+    await _checkBlocks();
+    setState(() => _showGrid = true);
+  }
+
   @override
   Widget build(BuildContext context) {
     Widget body;
@@ -92,11 +102,11 @@ class _POSSHomePageState extends State<POSSHomePage> {
                 child: Text('Menu'),
               ),
               ListTile(
-                leading: const Icon(Icons.home),
-                title: const Text('Home'),
-                onTap: () {
+                leading: const Icon(Icons.folder),
+                title: const Text('My Blocks'),
+                onTap: () async {
                   Navigator.pop(context);
-                  setState(() => _showGrid = true);
+                  await _openMyBlocks();
                 },
               ),
               ListTile(

--- a/lib/web_tools/web_sign_in_dialog.dart
+++ b/lib/web_tools/web_sign_in_dialog.dart
@@ -1,0 +1,139 @@
+import 'package:flutter/material.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import '../services/google_auth_service.dart';
+import 'package:sign_in_with_apple/sign_in_with_apple.dart';
+
+Future<bool> showWebSignInDialog(BuildContext context) async {
+  final emailController = TextEditingController();
+  final passController = TextEditingController();
+  bool loading = false;
+  bool isLogin = true;
+  bool success = false;
+
+  await showDialog(
+    context: context,
+    barrierDismissible: false,
+    builder: (context) {
+      return StatefulBuilder(
+        builder: (context, setState) {
+          Future<void> handleEmail() async {
+            setState(() => loading = true);
+            try {
+              if (isLogin) {
+                await FirebaseAuth.instance.signInWithEmailAndPassword(
+                  email: emailController.text.trim(),
+                  password: passController.text.trim(),
+                );
+              } else {
+                await FirebaseAuth.instance.createUserWithEmailAndPassword(
+                  email: emailController.text.trim(),
+                  password: passController.text.trim(),
+                );
+              }
+              success = true;
+              if (context.mounted) Navigator.pop(context);
+            } catch (e) {
+              if (context.mounted) {
+                ScaffoldMessenger.of(context)
+                    .showSnackBar(SnackBar(content: Text(e.toString())));
+              }
+            }
+            if (context.mounted) setState(() => loading = false);
+          }
+
+          Future<void> handleGoogle() async {
+            setState(() => loading = true);
+            try {
+              final cred = await GoogleAuthService.signIn();
+              if (cred != null) {
+                success = true;
+                if (context.mounted) Navigator.pop(context);
+              }
+            } catch (e) {
+              if (context.mounted) {
+                ScaffoldMessenger.of(context)
+                    .showSnackBar(SnackBar(content: Text(e.toString())));
+              }
+            }
+            if (context.mounted) setState(() => loading = false);
+          }
+
+          Future<void> handleApple() async {
+            setState(() => loading = true);
+            try {
+              final appleCred = await SignInWithApple.getAppleIDCredential(
+                scopes: [
+                  AppleIDAuthorizationScopes.email,
+                  AppleIDAuthorizationScopes.fullName,
+                ],
+              );
+              final oauth = OAuthProvider('apple.com').credential(
+                idToken: appleCred.identityToken,
+                accessToken: appleCred.authorizationCode,
+              );
+              await FirebaseAuth.instance.signInWithCredential(oauth);
+              success = true;
+              if (context.mounted) Navigator.pop(context);
+            } catch (e) {
+              if (context.mounted) {
+                ScaffoldMessenger.of(context)
+                    .showSnackBar(SnackBar(content: Text(e.toString())));
+              }
+            }
+            if (context.mounted) setState(() => loading = false);
+          }
+
+          return AlertDialog(
+            title: Text(isLogin ? 'Sign In' : 'Create Account'),
+            content: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                TextField(
+                  controller: emailController,
+                  decoration: const InputDecoration(labelText: 'Email'),
+                ),
+                const SizedBox(height: 12),
+                TextField(
+                  controller: passController,
+                  obscureText: true,
+                  decoration: const InputDecoration(labelText: 'Password'),
+                ),
+                const SizedBox(height: 20),
+                if (loading) const CircularProgressIndicator() else Column(
+                  children: [
+                    ElevatedButton(
+                      onPressed: handleEmail,
+                      child: Text(isLogin ? 'Sign In' : 'Create'),
+                    ),
+                    TextButton(
+                      onPressed: () => setState(() => isLogin = !isLogin),
+                      child: Text(isLogin ? 'Create Account' : 'Have an account?'),
+                    ),
+                    const Divider(),
+                    ElevatedButton(
+                      onPressed: handleGoogle,
+                      child: const Text('Sign in with Google'),
+                    ),
+                    const SizedBox(height: 8),
+                    ElevatedButton(
+                      onPressed: handleApple,
+                      child: const Text('Sign in with Apple'),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.pop(context),
+                child: const Text('Cancel'),
+              ),
+            ],
+          );
+        },
+      );
+    },
+  );
+
+  return success;
+}


### PR DESCRIPTION
## Summary
- show modal sign-in dialog in web tools
- require sign-in when saving blocks
- prompt for sign-in when opening "My Blocks"
- integrate sign-in modal into drawer

## Testing
- `dart analyze` *(fails: command not found)*
- `flutter format lib/web_tools/web_sign_in_dialog.dart lib/web_tools/poss_block_builder.dart lib/web_tools/poss_home_page.dart lib/web_tools/poss_drawer.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854b033637083239487f8adc3f370e6