### PR TITLE
Document POSS auth state flow

### DIFF
--- a/lib/web_tools/README.md
+++ b/lib/web_tools/README.md
@@ -1,0 +1,40 @@
+# Web Tools
+
+This folder contains the Progressive Overload Scoring System (POSS) widgets used on the web version of Lift League.
+
+The home page listens for FirebaseAuth state changes so that a user's custom POSS blocks are fetched as soon as they sign in and hidden again when they sign out.
+
+
+## How it works
+
+`POSSHomePage` registers an auth listener in `initState`:
+
+```dart
+_authSub = FirebaseAuth.instance.authStateChanges().listen((_) {
+  _checkBlocks();
+});
+```
+
+Whenever the auth status changes, `_checkBlocks()` loads blocks for the current user:
+
+```dart
+final blocks = await WebCustomBlockService().getCustomBlocks();
+setState(() {
+  _showGrid = blocks.isNotEmpty;
+  _loading = false;
+});
+```
+
+`WebCustomBlockService` uses the signed-in user's UID when querying Firestore:
+
+```dart
+final user = FirebaseAuth.instance.currentUser;
+if (user == null) return [];
+final snap = await FirebaseFirestore.instance
+    .collection('users')
+    .doc(user.uid)
+    .collection('custom_blocks')
+    .get();
+```
+
+When the list is empty (for example after signing out), the grid is hidden and the default tool state is shown.

--- a/lib/web_tools/poss_home_page.dart
+++ b/lib/web_tools/poss_home_page.dart
@@ -28,6 +28,8 @@ class _POSSHomePageState extends State<POSSHomePage> {
   void initState() {
     super.initState();
     _checkBlocks();
+    // Reload blocks whenever the user signs in or out so the
+    // UI reflects the correct state immediately.
     _authSub = FirebaseAuth.instance.authStateChanges().listen((_) {
       _checkBlocks();
     });
@@ -35,6 +37,7 @@ class _POSSHomePageState extends State<POSSHomePage> {
 
   Future<void> _checkBlocks() async {
     try {
+      // Grab blocks belonging to the currently signed-in user.
       final blocks = await WebCustomBlockService().getCustomBlocks();
       setState(() {
         _showGrid = blocks.isNotEmpty;


### PR DESCRIPTION
## Summary
- document how POSS home page listens for auth changes and loads blocks
- add comments clarifying auth-based block fetching

## Testing
- `Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_e_6854b199d0688323b3940445198f11a5