### PR TITLE
Add sign out button to POSS web

### DIFF
--- a/lib/web_tools/README.md
+++ b/lib/web_tools/README.md
@@ -65,3 +65,24 @@ returns all blocks owned by that UID, ensuring a consistent list everywhere.
 
 Only the collection scoped to the current UID is queried so there is no chance of
 loading another user's blocks.
+
+## Signing out
+
+The drawer displays a **Sign Out** tile whenever a user is authenticated. Pressing
+it calls `FirebaseAuth.instance.signOut()` and clears the custom block grid so the
+guest view is shown again:
+
+```dart
+ListTile(
+  leading: const Icon(Icons.logout),
+  title: const Text('Sign Out'),
+  onTap: () async {
+    Navigator.pop(context);
+    await FirebaseAuth.instance.signOut();
+    setState(() => _showGrid = false);
+  },
+)
+```
+
+The auth listener on `POSSHomePage` then reloads the (now empty) block list,
+displaying the default POSS interface for guests.

--- a/lib/web_tools/poss_home_page.dart
+++ b/lib/web_tools/poss_home_page.dart
@@ -188,6 +188,33 @@ class _POSSHomePageState extends State<POSSHomePage> {
                   );
                 },
               ),
+              const Divider(),
+              Builder(
+                builder: (context) {
+                  final user = FirebaseAuth.instance.currentUser;
+                  if (user == null) {
+                    return ListTile(
+                      leading: const Icon(Icons.login),
+                      title: const Text('Sign In'),
+                      onTap: () async {
+                        Navigator.pop(context);
+                        final signedIn = await showWebSignInDialog(context);
+                        if (signedIn) await _checkBlocks();
+                      },
+                    );
+                  } else {
+                    return ListTile(
+                      leading: const Icon(Icons.logout),
+                      title: const Text('Sign Out'),
+                      onTap: () async {
+                        Navigator.pop(context);
+                        await FirebaseAuth.instance.signOut();
+                        if (mounted) setState(() => _showGrid = false);
+                      },
+                    );
+                  }
+                },
+              ),
             ],
           ),
         ),


### PR DESCRIPTION
## Summary
- add sign in/out tile to POSS home drawer so users can sign out
- document how the drawer calls `FirebaseAuth.instance.signOut()`

## Testing
- `flutter format lib/web_tools/poss_home_page.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854b476ed2483238082884555578032