### PR TITLE
Add remove option in training circle members list

### DIFF
--- a/lib/screens/training_circle_members_screen.dart
+++ b/lib/screens/training_circle_members_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'public_profile_screen.dart';
+import '../services/user_follow_service.dart';
 
 class TrainingCircleMembersScreen extends StatelessWidget {
   const TrainingCircleMembersScreen({super.key});
@@ -55,42 +56,87 @@ class TrainingCircleMembersScreen extends StatelessWidget {
             itemCount: users.length,
             itemBuilder: (context, index) {
               final user = users[index];
-              final profileUrl = user['profileImageUrl'];
-              return ListTile(
-                leading: CircleAvatar(
-                  backgroundImage: (profileUrl != null &&
-                          profileUrl.toString().startsWith('http'))
-                      ? NetworkImage(profileUrl)
-                      : const AssetImage('assets/images/flatLogo.jpg')
-                          as ImageProvider,
-                ),
-                title: Text(
-                  user['displayName'] ?? 'Unknown',
-                  style: const TextStyle(
-                      color: Color(0xFFFC3B3D), fontWeight: FontWeight.bold),
-                ),
-                subtitle: Text(
-                  user['title'] ?? '',
-                  style: const TextStyle(
-                    color: Colors.white70,
-                    fontStyle: FontStyle.italic,
-                    fontSize: 12,
-                  ),
-                ),
-                onTap: () {
-                  Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                      builder: (_) => PublicProfileScreen(
-                        userId: user['userId'],
-                      ),
-                    ),
-                  );
-                },
-              );
+              return _CircleMemberTile(user: user);
             },
           );
         },
+      ),
+    );
+  }
+}
+
+class _CircleMemberTile extends StatefulWidget {
+  final Map<String, dynamic> user;
+
+  const _CircleMemberTile({required this.user});
+
+  @override
+  State<_CircleMemberTile> createState() => _CircleMemberTileState();
+}
+
+class _CircleMemberTileState extends State<_CircleMemberTile> {
+  late bool inCircle;
+
+  @override
+  void initState() {
+    super.initState();
+    inCircle = true;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final user = widget.user;
+    final profileUrl = user['profileImageUrl'];
+
+    return ListTile(
+      onTap: () {
+        Navigator.push(
+          context,
+          MaterialPageRoute(
+            builder: (_) => PublicProfileScreen(userId: user['userId']),
+          ),
+        );
+      },
+      leading: CircleAvatar(
+        backgroundImage: profileUrl != null &&
+                profileUrl.toString().startsWith('http')
+            ? NetworkImage(profileUrl)
+            : const AssetImage('assets/images/flatLogo.jpg') as ImageProvider,
+      ),
+      title: Text(
+        user['displayName'] ?? 'Unknown',
+        style: const TextStyle(
+            color: Color(0xFFFC3B3D), fontWeight: FontWeight.bold),
+      ),
+      subtitle: Text(
+        user['title'] ?? '',
+        style: const TextStyle(
+          color: Colors.white70,
+          fontStyle: FontStyle.italic,
+          fontSize: 12,
+        ),
+      ),
+      trailing: ElevatedButton(
+        onPressed: () async {
+          final currentUserId = FirebaseAuth.instance.currentUser?.uid;
+          if (currentUserId == null) return;
+          if (inCircle) {
+            await UserFollowService()
+                .removeFromTrainingCircle(currentUserId, user['userId']);
+          } else {
+            await UserFollowService().addToTrainingCircle(currentUserId, {
+              'userId': user['userId'],
+              'displayName': user['displayName'],
+              'profileImageUrl': user['profileImageUrl'],
+              'title': user['title'],
+            });
+          }
+          setState(() => inCircle = !inCircle);
+        },
+        style: ElevatedButton.styleFrom(
+          backgroundColor: inCircle ? Colors.red : Colors.blue,
+        ),
+        child: Text(inCircle ? 'Remove' : 'Add'),
       ),
     );
   }


### PR DESCRIPTION
## Summary
- enable removing users from TrainingCircleMembersScreen
- add `_CircleMemberTile` to mirror FollowingScreen behavior

## Testing
- `dart format -o none -l 120 lib/screens/training_circle_members_screen.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859c53f084483238e25577cc8c45803