### PR TITLE
Fix async error handling on stats

### DIFF
--- a/lib/screens/user_stats_screen.dart
+++ b/lib/screens/user_stats_screen.dart
@@ -176,6 +176,12 @@ class _UserStatsScreenState extends State<UserStatsScreen> {
           FutureBuilder<List<String>>(
             future: _layoutFuture,
             builder: (context, snapshot) {
+              if (snapshot.hasError) {
+                return IconButton(
+                  onPressed: null,
+                  icon: const Icon(Icons.error),
+                );
+              }
               if (!snapshot.hasData) return const SizedBox.shrink();
               return IconButton(
                 icon: const Icon(Icons.tune),
@@ -203,6 +209,9 @@ class _UserStatsScreenState extends State<UserStatsScreen> {
       body: FutureBuilder<Map<String, dynamic>?>(
         future: _userFuture,
         builder: (context, snapshot) {
+          if (snapshot.hasError) {
+            return Center(child: Text('Error: ${snapshot.error}'));
+          }
           if (!snapshot.hasData) {
             return const Center(child: CircularProgressIndicator());
           }
@@ -214,6 +223,9 @@ class _UserStatsScreenState extends State<UserStatsScreen> {
           return FutureBuilder<List<String>>(
             future: _layoutFuture,
             builder: (context, layoutSnap) {
+              if (layoutSnap.hasError) {
+                return Center(child: Text('Error: ${layoutSnap.error}'));
+              }
               if (!layoutSnap.hasData) {
                 return const Center(child: CircularProgressIndicator());
               }

--- a/lib/widgets/badge_display.dart
+++ b/lib/widgets/badge_display.dart
@@ -128,6 +128,9 @@ class BadgeDisplay extends StatelessWidget {
     return FutureBuilder<Map<String, dynamic>>(
       future: _fetchData(),
       builder: (context, snapshot) {
+        if (snapshot.hasError) {
+          return Center(child: Text('Error: ${snapshot.error}'));
+        }
         if (!snapshot.hasData) {
           return const Center(child: CircularProgressIndicator());
         }

--- a/lib/widgets/big_three_prs.dart
+++ b/lib/widgets/big_three_prs.dart
@@ -29,6 +29,9 @@ class BigThreePRs extends StatelessWidget {
     return FutureBuilder<Map<String, double>>(
       future: _fetchPRs(),
       builder: (context, snapshot) {
+        if (snapshot.hasError) {
+          return Center(child: Text('Error: ${snapshot.error}'));
+        }
         if (!snapshot.hasData) {
           return const Center(child: CircularProgressIndicator());
         }

--- a/lib/widgets/checkin_graph.dart
+++ b/lib/widgets/checkin_graph.dart
@@ -160,6 +160,9 @@ class _CheckInGraphState extends State<CheckInGraph> {
     return FutureBuilder<Map<String, List<FlSpot>>>(
       future: _fetchData(),
       builder: (context, snapshot) {
+        if (snapshot.hasError) {
+          return Center(child: Text('Error: ${snapshot.error}'));
+        }
         if (!snapshot.hasData) {
           return const Center(child: CircularProgressIndicator());
         }

--- a/lib/widgets/consistency_meter.dart
+++ b/lib/widgets/consistency_meter.dart
@@ -34,6 +34,11 @@ class _ConsistencyMeterState extends State<ConsistencyMeter> {
     return StreamBuilder<Map<String, dynamic>>(
       stream: _consistencyStream,
       builder: (context, snapshot) {
+        if (snapshot.hasError) {
+          return SizedBox(
+              height: 60,
+              child: Center(child: Text('Error: ${snapshot.error}')));
+        }
         if (!snapshot.hasData) {
           return const SizedBox(
               height: 60, child: Center(child: CircularProgressIndicator()));

--- a/lib/widgets/efficiency_meter.dart
+++ b/lib/widgets/efficiency_meter.dart
@@ -168,6 +168,9 @@ class _EfficiencyMeterState extends State<EfficiencyMeter> {
     return StreamBuilder<Map<String, dynamic>>(
       stream: _statsStream,
       builder: (context, snapshot) {
+        if (snapshot.hasError) {
+          return Center(child: Text('Error: ${snapshot.error}'));
+        }
         if (!snapshot.hasData) {
           return const Center(child: CircularProgressIndicator());
         }

--- a/lib/widgets/lifetime_stats.dart
+++ b/lib/widgets/lifetime_stats.dart
@@ -22,6 +22,9 @@ class LifetimeStats extends StatelessWidget {
     return FutureBuilder<Map<String, dynamic>>(
       future: _fetchStats(),
       builder: (context, snapshot) {
+        if (snapshot.hasError) {
+          return Center(child: Text('Error: ${snapshot.error}'));
+        }
         if (!snapshot.hasData) {
           return const Center(child: CircularProgressIndicator());
         }

--- a/lib/widgets/momentum_meter.dart
+++ b/lib/widgets/momentum_meter.dart
@@ -86,6 +86,9 @@ class _MomentumMeterState extends State<MomentumMeter> {
     return StreamBuilder<Map<String, dynamic>>(
       stream: _momentumStream,
       builder: (context, snapshot) {
+        if (snapshot.hasError) {
+          return Center(child: Text('Error: ${snapshot.error}'));
+        }
         if (!snapshot.hasData) {
           return const Center(child: CircularProgressIndicator());
         }

--- a/lib/widgets/stats/body_weight_chart.dart
+++ b/lib/widgets/stats/body_weight_chart.dart
@@ -163,9 +163,12 @@ class _BodyWeightChartState extends State<BodyWeightChart> {
 
   @override
   Widget build(BuildContext context) {
-    return FutureBuilder<Map<String, dynamic>>( 
+    return FutureBuilder<Map<String, dynamic>>(
       future: _fetchData(),
       builder: (context, snapshot) {
+        if (snapshot.hasError) {
+          return Center(child: Text('Error: ${snapshot.error}'));
+        }
         if (!snapshot.hasData) {
           return const Center(child: CircularProgressIndicator());
         }

--- a/lib/widgets/stats/calories_workout_chart.dart
+++ b/lib/widgets/stats/calories_workout_chart.dart
@@ -195,6 +195,9 @@ class _CaloriesWorkoutChartState extends State<CaloriesWorkoutChart> {
     return FutureBuilder<Map<String, dynamic>>(
       future: _fetchData(),
       builder: (context, snapshot) {
+        if (snapshot.hasError) {
+          return Center(child: Text('Error: ${snapshot.error}'));
+        }
         if (!snapshot.hasData) {
           return const Center(child: CircularProgressIndicator());
         }

--- a/lib/widgets/stats/widget_picker_bottom_sheet.dart
+++ b/lib/widgets/stats/widget_picker_bottom_sheet.dart
@@ -41,10 +41,17 @@ class _WidgetPickerBottomSheetState extends State<WidgetPickerBottomSheet> {
 
   Future<void> _save() async {
     final layout = _items.where((e) => e.enabled).map((e) => e.id).toList();
-    await FirebaseFirestore.instance
-        .doc('users/${widget.userId}/preferences')
-        .set({'statsLayout': layout}, SetOptions(merge: true));
-    if (mounted) Navigator.pop(context, layout);
+    try {
+      await FirebaseFirestore.instance
+          .doc('users/${widget.userId}/preferences')
+          .set({'statsLayout': layout}, SetOptions(merge: true));
+      if (mounted) Navigator.pop(context, layout);
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context)
+            .showSnackBar(SnackBar(content: Text('Error saving: $e')));
+      }
+    }
   }
 
   @override


### PR DESCRIPTION
## Summary
- show error states for FutureBuilder and StreamBuilder widgets
- catch Firestore save error in widget picker bottom sheet

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859dcc6a8688323871d39c551b6906b