### PR TITLE
Center POSSBlockBuilder widget

### DIFF
--- a/lib/web_tools/poss_block_builder.dart
+++ b/lib/web_tools/poss_block_builder.dart
@@ -235,8 +235,12 @@ class _POSSBlockBuilderState extends State<POSSBlockBuilder> {
           padding: EdgeInsets.only(
             bottom: MediaQuery.of(context).viewInsets.bottom,
           ),
-          child: Stepper(
-            currentStep: _currentStep,
+          child: Align(
+            alignment: Alignment.topCenter,
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 600),
+              child: Stepper(
+                currentStep: _currentStep,
             onStepContinue: () {
               if (_currentStep == 0) {
                 if (blockName.trim().isNotEmpty) {
@@ -366,7 +370,9 @@ class _POSSBlockBuilderState extends State<POSSBlockBuilder> {
         ),
         ),
       ),
-    );
+    ),
+  ),
+);
   }
 
   @override


### PR DESCRIPTION
## Summary
- wrap `POSSBlockBuilder`'s `Stepper` in an `Align` and `ConstrainedBox`
- close new layout widgets

## Testing
- `Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_e_6859ebec8a188323a7bc1619b69d7612