### PR TITLE
Fix Firestore path for user stats layout

### DIFF
--- a/lib/screens/user_stats_screen.dart
+++ b/lib/screens/user_stats_screen.dart
@@ -80,7 +80,10 @@ class _UserStatsScreenState extends State<UserStatsScreen> {
 
   Future<List<String>> _fetchLayout() async {
     final doc = await FirebaseFirestore.instance
-        .doc('users/${widget.userId}/preferences')
+        .collection('users')
+        .doc(widget.userId)
+        .collection('preferences')
+        .doc('stats')
         .get();
     final data = doc.data();
     if (data != null && data['statsLayout'] is List) {

--- a/lib/widgets/stats/widget_picker_bottom_sheet.dart
+++ b/lib/widgets/stats/widget_picker_bottom_sheet.dart
@@ -43,7 +43,10 @@ class _WidgetPickerBottomSheetState extends State<WidgetPickerBottomSheet> {
     final layout = _items.where((e) => e.enabled).map((e) => e.id).toList();
     try {
       await FirebaseFirestore.instance
-          .doc('users/${widget.userId}/preferences')
+          .collection('users')
+          .doc(widget.userId)
+          .collection('preferences')
+          .doc('stats')
           .set({'statsLayout': layout}, SetOptions(merge: true));
       if (mounted) Navigator.pop(context, layout);
     } catch (e) {


### PR DESCRIPTION
## Summary
- fix `user_stats_screen` Firestore path
- update widget picker bottom sheet save path

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859f082d04c83239391bb8a2a32fef1