### PR TITLE
Open dashboard after building block on web

### DIFF
--- a/lib/web_tools/poss_block_builder.dart
+++ b/lib/web_tools/poss_block_builder.dart
@@ -16,6 +16,7 @@ import '../models/custom_block_models.dart';
 import '../screens/workout_builder.dart';
 import '../services/db_service.dart';
 import '../screens/block_dashboard.dart';
+import 'web_block_dashboard.dart';
 
 const Color _lightGrey = Color(0xFFD0D0D0);
 
@@ -184,7 +185,12 @@ class _POSSBlockBuilderState extends State<POSSBlockBuilder> {
       if (mounted) {
         ScaffoldMessenger.of(context)
             .showSnackBar(const SnackBar(content: Text('Block saved!')));
-        Navigator.pop(context);
+        Navigator.pushReplacement(
+          context,
+          MaterialPageRoute(
+            builder: (_) => WebBlockDashboard(block: block),
+          ),
+        );
       }
       widget.onSaved?.call();
       return;

--- a/lib/web_tools/web_block_dashboard.dart
+++ b/lib/web_tools/web_block_dashboard.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+import '../models/custom_block_models.dart';
+
+class WebBlockDashboard extends StatelessWidget {
+  final CustomBlock block;
+  const WebBlockDashboard({super.key, required this.block});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(block.name),
+      ),
+      body: ListView.builder(
+        itemCount: block.workouts.length,
+        itemBuilder: (context, index) {
+          final workout = block.workouts[index];
+          final week = index ~/ block.daysPerWeek + 1;
+          final day = index % block.daysPerWeek + 1;
+          return Card(
+            margin: const EdgeInsets.all(8),
+            child: ExpansionTile(
+              title: Text('Week $week - Day $day: ${workout.name}'),
+              children: workout.lifts
+                  .map(
+                    (l) => ListTile(
+                      title: Text(l.name),
+                      subtitle: Text('${l.sets} x ${l.repsPerSet}'),
+                    ),
+                  )
+                  .toList(),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- navigate to a simple dashboard after building a block on web
- added `WebBlockDashboard` with basic workout listing

## Testing
- `dart format lib/web_tools/web_block_dashboard.dart lib/web_tools/poss_block_builder.dart` *(fails: `bash: dart: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6859fc98ba508323b30239eee931409c