### PR TITLE
Fix rest timer chime audio focus

### DIFF
--- a/lib/services/rest_timer_service.dart
+++ b/lib/services/rest_timer_service.dart
@@ -28,6 +28,19 @@ class RestTimerService {
   Future<void> _playChime() async {
     if (!_playSound) return;
     try {
+      await _audioPlayer.setAudioContext(
+        const AudioContext(
+          android: AudioContextAndroid(
+            contentType: AndroidContentType.sonification,
+            usage: AndroidUsage.alarm,
+            audioFocus: AndroidAudioFocus.gainTransientExclusive,
+          ),
+          iOS: AudioContextIOS(
+            category: AVAudioSessionCategory.playback,
+            options: [AVAudioSessionOptions.duckOthers],
+          ),
+        ),
+      );
       await _audioPlayer.play(AssetSource('sounds/chime.wav'));
       await _audioPlayer.onPlayerComplete.first;
       await _audioPlayer.release();

--- a/lib/widgets/rest_timer.dart
+++ b/lib/widgets/rest_timer.dart
@@ -47,6 +47,7 @@ class _RestTimerState extends State<RestTimer> {
         padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
         minimumSize: Size.zero,
         tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+        enableFeedback: false,
       ),
       child: Text(
         label,
@@ -84,6 +85,7 @@ class _RestTimerState extends State<RestTimer> {
               constraints: const BoxConstraints(), // remove built-in size
               visualDensity: VisualDensity.compact, // remove vertical space
               tooltip: 'Restart Last Timer',
+              enableFeedback: false,
             ),
             const SizedBox(width: 6),
             Text(


### PR DESCRIPTION
## Summary
- avoid haptic feedback when starting the rest timer
- play the chime using an audio context that requests transient focus

## Testing
- `flutter analyze` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685acdde7d2c8323a01f1ba712bf3960