### PR TITLE
Fix skipped sets on finalize

### DIFF
--- a/lib/modals/numpad_modal.dart
+++ b/lib/modals/numpad_modal.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
 class NumpadModal extends StatelessWidget {
-  final Function(String) onKeyPressed;
+  final Future<void> Function(String) onKeyPressed;
 
   const NumpadModal({super.key, required this.onKeyPressed});
 

--- a/lib/screens/lift_entry.dart
+++ b/lib/screens/lift_entry.dart
@@ -279,9 +279,9 @@ class _LiftEntryState extends State<LiftEntry> with AutomaticKeepAliveClientMixi
 
   // 🔒 Public method called when the numpad "Done" button is pressed
   // to force calculation and persistence of lift data.
-  void finalizeLift() {
+  Future<void> finalizeLift() async {
     _recalculateLiftTotals();
-    updateStoredData();
+    await updateStoredData();
 
     widget.onLiftDataChanged?.call(
       _liftScore,

--- a/lib/screens/workout_log.dart
+++ b/lib/screens/workout_log.dart
@@ -248,7 +248,7 @@ class WorkoutLogScreenState extends State<WorkoutLogScreen> with SingleTickerPro
     }
   }
 
-  void _handleNumpadPress(String value) {
+  Future<void> _handleNumpadPress(String value) async {
     final controller = _controllerMap[_activeFieldKey];
     if (controller == null) return;
 
@@ -265,7 +265,7 @@ class WorkoutLogScreenState extends State<WorkoutLogScreen> with SingleTickerPro
             final key = _liftEntryKeys[liftId];
             if (key?.currentState != null) {
               final dynamic state = key!.currentState;
-              state.finalizeLift();
+              await state.finalizeLift();
             }
           }
         }


### PR DESCRIPTION
## Summary
- make `finalizeLift` asynchronous and await DB update
- ensure numpad uses async handler for `done` key

## Testing
- `flutter --version` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ae9073e84832396ac7591975ad216