### PR TITLE
Fix avg lift calculation

### DIFF
--- a/lib/widgets/efficiency_meter.dart
+++ b/lib/widgets/efficiency_meter.dart
@@ -81,7 +81,10 @@ class _EfficiencyMeterState extends State<EfficiencyMeter> {
       SELECT AVG(lt.liftScore) as s
       FROM lift_totals lt
       JOIN workout_instances wi ON lt.workoutInstanceId = wi.workoutInstanceId
-      WHERE wi.blockInstanceId = ? AND wi.week = ? AND lt.userId = ?
+      WHERE wi.blockInstanceId = ?
+        AND wi.week = ?
+        AND lt.userId = ?
+        AND lt.liftReps > 0
     ''', [blockInstanceId, week, widget.userId]);
 
     final avgWorkoutRes = await db.rawQuery('''


### PR DESCRIPTION
## Summary
- adjust EfficiencyMeter lift score query to skip unperformed lifts

## Testing
- `dart format -o none --set-exit-if-changed lib/widgets/efficiency_meter.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685aed17e7d8832396b2a427a5335704