### PR TITLE
Fix RestTimer startup vibration

### DIFF
--- a/lib/services/notifications_service.dart
+++ b/lib/services/notifications_service.dart
@@ -101,13 +101,14 @@ class NotificationService {
     const AndroidNotificationDetails androidDetails = AndroidNotificationDetails(
       'rest_timer',
       'Rest Timer',
-      importance: Importance.max,
-      priority: Priority.high,
+      importance: Importance.low,
+      priority: Priority.low,
       icon: 'ic_stat_liftleague',
       ongoing: true,
       showWhen: false,
       onlyAlertOnce: true,
       enableVibration: false,
+      playSound: false,
     );
 
     const NotificationDetails details = NotificationDetails(android: androidDetails);


### PR DESCRIPTION
## Summary
- disable sound and vibration on ongoing rest timer notifications

## Testing
- `flutter format lib/services/notifications_service.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b0c7d5fb883238939fa8e15e681ed