### PR TITLE
Sync web custom blocks with mobile app

### DIFF
--- a/lib/web_tools/poss_block_builder.dart
+++ b/lib/web_tools/poss_block_builder.dart
@@ -115,12 +115,18 @@ class _POSSBlockBuilderState extends State<POSSBlockBuilder> {
           .collection('custom_blocks')
           .doc(block.id.toString())
           .set(blockData);
+
+      // Also store under the global collection so blocks created on the web
+      // are available and shareable in the mobile app just like those built
+      // on mobile.
+      await FirebaseFirestore.instance
+          .collection('custom_blocks')
+          .doc(block.id.toString())
+          .set(blockData);
     } else {
       return;
     }
-
-    // In the web tool we only persist blocks under the current user's document
-    // so that each user sees only their own data.
+    // Blocks are saved for the signed-in user and globally for sharing.
   }
 
 


### PR DESCRIPTION
## Summary
- save web custom blocks both under the user's document and globally so they are shareable and usable on mobile

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b0fddd9c88323a91993ae6c12dec5