### PR TITLE
Enable custom block logging on web

### DIFF
--- a/lib/web_tools/custom_blocks_screen.dart
+++ b/lib/web_tools/custom_blocks_screen.dart
@@ -78,14 +78,34 @@ class _CustomBlocksScreenState extends State<CustomBlocksScreen> {
                 imageWidget = Image.network(path, fit: BoxFit.cover);
               }
               return InkWell(
-                onTap: () {
+                onTap: () async {
                   final block = CustomBlock.fromMap(b);
-                  Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                      builder: (_) => WebBlockDashboard(block: block),
-                    ),
-                  );
+                  try {
+                    final runId =
+                        await WebCustomBlockService().startBlockRun(block);
+                    if (!mounted) return;
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (_) =>
+                            WebBlockDashboard(block: block, runId: runId),
+                      ),
+                    );
+                  } on FirebaseException catch (e) {
+                    final reauthed = await promptReAuthIfNeeded(context, e);
+                    if (reauthed) {
+                      final runId =
+                          await WebCustomBlockService().startBlockRun(block);
+                      if (!mounted) return;
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (_) =>
+                              WebBlockDashboard(block: block, runId: runId),
+                        ),
+                      );
+                    }
+                  }
                 },
                 child: Card(
                   clipBehavior: Clip.antiAlias,

--- a/lib/web_tools/poss_block_builder.dart
+++ b/lib/web_tools/poss_block_builder.dart
@@ -17,6 +17,7 @@ import '../screens/workout_builder.dart';
 import '../services/db_service.dart';
 import '../screens/block_dashboard.dart';
 import 'web_block_dashboard.dart';
+import 'web_custom_block_service.dart';
 
 const Color _lightGrey = Color(0xFFD0D0D0);
 
@@ -180,23 +181,36 @@ class _POSSBlockBuilderState extends State<POSSBlockBuilder> {
     if (kIsWeb) {
       try {
         await _saveBlockToFirestore(block);
+        final runId = await WebCustomBlockService().startBlockRun(block);
+        if (mounted) {
+          ScaffoldMessenger.of(context)
+              .showSnackBar(const SnackBar(content: Text('Block saved!')));
+          Navigator.pushReplacement(
+            context,
+            MaterialPageRoute(
+              builder: (_) =>
+                  WebBlockDashboard(block: block, runId: runId),
+            ),
+          );
+        }
       } on FirebaseException catch (e) {
         final reauthed = await promptReAuthIfNeeded(context, e);
         if (reauthed) {
-          await _saveBlockToFirestore(block);
+          final runId = await WebCustomBlockService().startBlockRun(block);
+          if (mounted) {
+            ScaffoldMessenger.of(context)
+                .showSnackBar(const SnackBar(content: Text('Block saved!')));
+            Navigator.pushReplacement(
+              context,
+              MaterialPageRoute(
+                builder: (_) =>
+                    WebBlockDashboard(block: block, runId: runId),
+              ),
+            );
+          }
         } else {
           return;
         }
-      }
-      if (mounted) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(const SnackBar(content: Text('Block saved!')));
-        Navigator.pushReplacement(
-          context,
-          MaterialPageRoute(
-            builder: (_) => WebBlockDashboard(block: block),
-          ),
-        );
       }
       widget.onSaved?.call();
       return;

--- a/lib/web_tools/web_block_dashboard.dart
+++ b/lib/web_tools/web_block_dashboard.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
 import '../models/custom_block_models.dart';
+import 'web_workout_log.dart';
 
 class WebBlockDashboard extends StatelessWidget {
   final CustomBlock block;
-  const WebBlockDashboard({super.key, required this.block});
+  final String? runId;
+  const WebBlockDashboard({super.key, required this.block, this.runId});
 
   @override
   Widget build(BuildContext context) {
@@ -21,14 +23,34 @@ class WebBlockDashboard extends StatelessWidget {
             margin: const EdgeInsets.all(8),
             child: ExpansionTile(
               title: Text('Week $week - Day $day: ${workout.name}'),
-              children: workout.lifts
-                  .map(
-                    (l) => ListTile(
-                      title: Text(l.name),
-                      subtitle: Text('${l.sets} x ${l.repsPerSet}'),
+              children: [
+                ...workout.lifts.map(
+                  (l) => ListTile(
+                    title: Text(l.name),
+                    subtitle: Text('${l.sets} x ${l.repsPerSet}'),
+                  ),
+                ),
+                if (runId != null)
+                  Align(
+                    alignment: Alignment.centerRight,
+                    child: TextButton.icon(
+                      onPressed: () {
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (_) => WebWorkoutLog(
+                              runId: runId!,
+                              workoutIndex: index,
+                              block: block,
+                            ),
+                          ),
+                        );
+                      },
+                      icon: const Icon(Icons.play_arrow),
+                      label: const Text('Log Workout'),
                     ),
-                  )
-                  .toList(),
+                  ),
+              ],
             ),
           );
         },

--- a/lib/web_tools/web_custom_block_service.dart
+++ b/lib/web_tools/web_custom_block_service.dart
@@ -1,5 +1,6 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
+import '../models/custom_block_models.dart';
 
 class WebCustomBlockService {
   Future<List<Map<String, dynamic>>> getCustomBlocks() async {
@@ -15,5 +16,52 @@ class WebCustomBlockService {
       data['id'] = int.tryParse(d.id) ?? 0;
       return data;
     }).toList();
+  }
+
+  /// Creates a new block run for [block] and returns the run document ID.
+  Future<String> startBlockRun(CustomBlock block) async {
+    final user = FirebaseAuth.instance.currentUser;
+    if (user == null) {
+      throw FirebaseAuthException(
+          code: 'unauthenticated', message: 'User not signed in');
+    }
+
+    final runRef = FirebaseFirestore.instance
+        .collection('users')
+        .doc(user.uid)
+        .collection('block_runs')
+        .doc();
+
+    await runRef.set({
+      'blockName': block.name,
+      'createdAt': FieldValue.serverTimestamp(),
+      'numWeeks': block.numWeeks,
+      'daysPerWeek': block.daysPerWeek,
+    });
+
+    for (int wIndex = 0; wIndex < block.workouts.length; wIndex++) {
+      final workout = block.workouts[wIndex];
+      final workoutRef =
+          runRef.collection('workouts').doc(wIndex.toString());
+      await workoutRef.set({
+        'name': workout.name,
+        'dayIndex': workout.dayIndex,
+      });
+
+      for (int lIndex = 0; lIndex < workout.lifts.length; lIndex++) {
+        final lift = workout.lifts[lIndex];
+        await workoutRef.collection('lifts').doc(lIndex.toString()).set({
+          'name': lift.name,
+          'sets': lift.sets,
+          'repsPerSet': lift.repsPerSet,
+          'multiplier': lift.multiplier,
+          'isBodyweight': lift.isBodyweight,
+          'isDumbbellLift': lift.isDumbbellLift,
+          'completedSets': <int>[],
+        });
+      }
+    }
+
+    return runRef.id;
   }
 }

--- a/lib/web_tools/web_workout_log.dart
+++ b/lib/web_tools/web_workout_log.dart
@@ -1,0 +1,104 @@
+import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import '../models/custom_block_models.dart';
+
+class WebWorkoutLog extends StatefulWidget {
+  final String runId;
+  final int workoutIndex;
+  final CustomBlock block;
+  const WebWorkoutLog({super.key, required this.runId, required this.workoutIndex, required this.block});
+
+  @override
+  State<WebWorkoutLog> createState() => _WebWorkoutLogState();
+}
+
+class _WebWorkoutLogState extends State<WebWorkoutLog> {
+  late final WorkoutDraft workout;
+  final Map<int, Set<int>> _completed = {};
+
+  @override
+  void initState() {
+    super.initState();
+    workout = widget.block.workouts[widget.workoutIndex];
+    _loadCompletion();
+  }
+
+  Future<void> _loadCompletion() async {
+    final user = FirebaseAuth.instance.currentUser;
+    if (user == null) return;
+    for (int i = 0; i < workout.lifts.length; i++) {
+      final doc = await FirebaseFirestore.instance
+          .collection('users')
+          .doc(user.uid)
+          .collection('block_runs')
+          .doc(widget.runId)
+          .collection('workouts')
+          .doc(widget.workoutIndex.toString())
+          .collection('lifts')
+          .doc(i.toString())
+          .get();
+      final List<dynamic> completed = doc.data()?['completedSets'] ?? [];
+      _completed[i] = Set<int>.from(completed);
+    }
+    if (mounted) setState(() {});
+  }
+
+  Future<void> _toggleSet(int liftIndex, int set) async {
+    final user = FirebaseAuth.instance.currentUser;
+    if (user == null) return;
+    final liftRef = FirebaseFirestore.instance
+        .collection('users')
+        .doc(user.uid)
+        .collection('block_runs')
+        .doc(widget.runId)
+        .collection('workouts')
+        .doc(widget.workoutIndex.toString())
+        .collection('lifts')
+        .doc(liftIndex.toString());
+    final snap = await liftRef.get();
+    final List<dynamic> completed = snap.data()?['completedSets'] ?? [];
+    _completed[liftIndex] = Set<int>.from(completed);
+    if (_completed[liftIndex]!.contains(set)) {
+      await liftRef.update({
+        'completedSets': FieldValue.arrayRemove([set])
+      });
+      _completed[liftIndex]!.remove(set);
+    } else {
+      await liftRef.update({
+        'completedSets': FieldValue.arrayUnion([set])
+      });
+      _completed[liftIndex]!.add(set);
+    }
+    setState(() {});
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(workout.name)),
+      body: ListView.builder(
+        itemCount: workout.lifts.length,
+        itemBuilder: (context, index) {
+          final lift = workout.lifts[index];
+          return Card(
+            margin: const EdgeInsets.all(8),
+            child: ExpansionTile(
+              title: Text(lift.name),
+              children: List.generate(lift.sets, (set) {
+                final checked = _completed[index]?.contains(set) ?? false;
+                return ListTile(
+                  leading: Checkbox(
+                    value: checked,
+                    onChanged: (_) => _toggleSet(index, set),
+                  ),
+                  title: Text('Set ${set + 1} - ${lift.repsPerSet} reps'),
+                );
+              }),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- expand `WebCustomBlockService` with a `startBlockRun` helper
- launch block runs from `POSSBlockBuilder` and `CustomBlocksScreen`
- extend `WebBlockDashboard` to allow workout logging
- implement simple `WebWorkoutLog` screen for web logging

## Testing
- `flutter format` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_685b34a9408c8323a7d22d516820fbd9