### PR TITLE
Align web block builder with mobile workflow

### DIFF
--- a/lib/web_tools/custom_blocks_screen.dart
+++ b/lib/web_tools/custom_blocks_screen.dart
@@ -15,7 +15,8 @@ class CustomBlocksScreen extends StatefulWidget {
 }
 
 class _CustomBlocksScreenState extends State<CustomBlocksScreen> {
-  List<Map<String, dynamic>> _blocks = [];
+  /// Stored list of blocks typed as [CustomBlock] to mirror mobile logic.
+  List<CustomBlock> _blocks = [];
   bool _loading = true;
 
   @override
@@ -68,10 +69,7 @@ class _CustomBlocksScreenState extends State<CustomBlocksScreen> {
             itemCount: _blocks.length,
             itemBuilder: (context, index) {
               final b = _blocks[index];
-              // Blocks saved from the web builder store the cover image under
-              // `coverImageUrl` while legacy blocks might use `coverImagePath`.
-              final path = b['coverImagePath']?.toString() ??
-                  b['coverImageUrl']?.toString() ?? 'assets/logo25.jpg';
+              final path = b.coverImagePath ?? 'assets/logo25.jpg';
               final Widget imageWidget;
               if (path.startsWith('assets/')) {
                 imageWidget = Image.asset(path, fit: BoxFit.cover);
@@ -80,7 +78,7 @@ class _CustomBlocksScreenState extends State<CustomBlocksScreen> {
               }
               return InkWell(
                 onTap: () {
-                  final id = b["id"].toString();
+                  final id = b.id.toString();
                   context.go('/custom-blocks/$id');
                 },
                 child: Card(
@@ -95,7 +93,7 @@ class _CustomBlocksScreenState extends State<CustomBlocksScreen> {
                           padding: const EdgeInsets.all(4),
                           width: double.infinity,
                           child: Text(
-                            b['name'] as String? ?? '',
+                            b.name,
                             textAlign: TextAlign.center,
                           ),
                         ),

--- a/lib/web_tools/poss_block_builder.dart
+++ b/lib/web_tools/poss_block_builder.dart
@@ -89,7 +89,6 @@ class _POSSBlockBuilderState extends State<POSSBlockBuilder> {
       'isDraft': block.isDraft,
       'coverImageUrl': imageUrl,
       'ownerId': user?.uid ?? '',
-      'source': 'web_custom_builder',
       'workouts': block.workouts
           .map((w) => {
                 'id': w.id,

--- a/lib/web_tools/web_custom_block_service.dart
+++ b/lib/web_tools/web_custom_block_service.dart
@@ -3,7 +3,9 @@ import 'package:firebase_auth/firebase_auth.dart';
 import '../models/custom_block_models.dart';
 
 class WebCustomBlockService {
-  Future<List<Map<String, dynamic>>> getCustomBlocks() async {
+  /// Returns all custom blocks for the signed-in user using the
+  /// [CustomBlock] model to mirror the mobile app structure.
+  Future<List<CustomBlock>> getCustomBlocks() async {
     final user = FirebaseAuth.instance.currentUser;
     if (user == null) return [];
     final snap = await FirebaseFirestore.instance
@@ -14,7 +16,7 @@ class WebCustomBlockService {
     return snap.docs.map((d) {
       final data = d.data();
       data['id'] = int.tryParse(d.id) ?? 0;
-      return data;
+      return CustomBlock.fromMap(data);
     }).toList();
   }
 


### PR DESCRIPTION
## Summary
- type custom block storage using `CustomBlock`
- simplify block display logic to use typed fields
- remove extra `source` field from web-built block data

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c2993f0ac8323bd0aae523eb7830b