### PR TITLE
Enable web custom block runs

### DIFF
--- a/lib/web_tools/web_block_dashboard.dart
+++ b/lib/web_tools/web_block_dashboard.dart
@@ -1,24 +1,72 @@
 import 'package:flutter/material.dart';
 import '../models/custom_block_models.dart';
 import 'web_workout_log.dart';
+import 'web_custom_block_service.dart';
+import 'auth_utils.dart';
+import 'web_sign_in_dialog.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_core/firebase_core.dart';
 
-class WebBlockDashboard extends StatelessWidget {
+class WebBlockDashboard extends StatefulWidget {
   final CustomBlock block;
   final String? runId;
   const WebBlockDashboard({super.key, required this.block, this.runId});
 
   @override
+  State<WebBlockDashboard> createState() => _WebBlockDashboardState();
+}
+
+class _WebBlockDashboardState extends State<WebBlockDashboard> {
+  String? _runId;
+  bool _starting = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _runId = widget.runId;
+  }
+
+  Future<void> _startRun() async {
+    if (_starting) return;
+    if (widget.block.workouts.isEmpty) return;
+    if (FirebaseAuth.instance.currentUser == null) {
+      final signedIn = await showWebSignInDialog(context);
+      if (!signedIn) return;
+    }
+    setState(() => _starting = true);
+    try {
+      final runId = await WebCustomBlockService().startBlockRun(widget.block);
+      if (!mounted) return;
+      setState(() => _runId = runId);
+      ScaffoldMessenger.of(context)
+          .showSnackBar(const SnackBar(content: Text('Block started')));
+    } on FirebaseException catch (e) {
+      final reauthed = await promptReAuthIfNeeded(context, e);
+      if (reauthed) {
+        await _startRun();
+      } else {
+        if (mounted) {
+          ScaffoldMessenger.of(context)
+              .showSnackBar(SnackBar(content: Text(e.message ?? e.code)));
+        }
+      }
+    } finally {
+      if (mounted) setState(() => _starting = false);
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text(block.name),
+        title: Text(widget.block.name),
       ),
       body: ListView.builder(
-        itemCount: block.workouts.length,
+        itemCount: widget.block.workouts.length,
         itemBuilder: (context, index) {
-          final workout = block.workouts[index];
-          final week = index ~/ block.daysPerWeek + 1;
-          final day = index % block.daysPerWeek + 1;
+          final workout = widget.block.workouts[index];
+          final week = index ~/ widget.block.daysPerWeek + 1;
+          final day = index % widget.block.daysPerWeek + 1;
           return Card(
             margin: const EdgeInsets.all(8),
             child: ExpansionTile(
@@ -30,7 +78,7 @@ class WebBlockDashboard extends StatelessWidget {
                     subtitle: Text('${l.sets} x ${l.repsPerSet}'),
                   ),
                 ),
-                if (runId != null)
+                if (_runId != null)
                   Align(
                     alignment: Alignment.centerRight,
                     child: TextButton.icon(
@@ -39,9 +87,9 @@ class WebBlockDashboard extends StatelessWidget {
                           context,
                           MaterialPageRoute(
                             builder: (_) => WebWorkoutLog(
-                              runId: runId!,
+                              runId: _runId!,
                               workoutIndex: index,
-                              block: block,
+                              block: widget.block,
                             ),
                           ),
                         );
@@ -55,6 +103,13 @@ class WebBlockDashboard extends StatelessWidget {
           );
         },
       ),
+      floatingActionButton: _runId == null
+          ? FloatingActionButton.extended(
+              onPressed: _startRun,
+              icon: const Icon(Icons.play_arrow),
+              label: const Text('Start Block'),
+            )
+          : null,
     );
   }
 }


### PR DESCRIPTION
## Summary
- allow starting custom block runs from the web block dashboard
- prompt for sign‑in before starting a run

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c341cbaf08323b378a136b2871419