### PR TITLE
Add draft support to web block builder

### DIFF
--- a/lib/web_tools/custom_blocks_screen.dart
+++ b/lib/web_tools/custom_blocks_screen.dart
@@ -86,6 +86,23 @@ class _CustomBlocksScreenState extends State<CustomBlocksScreen> {
                   child: Stack(
                     children: [
                       Positioned.fill(child: imageWidget),
+                      if (b['isDraft'] == true)
+                        Positioned(
+                          top: 4,
+                          left: 4,
+                          child: Container(
+                            color: Colors.black54,
+                            padding: const EdgeInsets.symmetric(
+                                horizontal: 4, vertical: 2),
+                            child: const Text(
+                              'DRAFT',
+                              style: TextStyle(
+                                color: Colors.white,
+                                fontSize: 12,
+                              ),
+                            ),
+                          ),
+                        ),
                       Align(
                         alignment: Alignment.bottomCenter,
                         child: Container(
@@ -93,7 +110,9 @@ class _CustomBlocksScreenState extends State<CustomBlocksScreen> {
                           padding: const EdgeInsets.all(4),
                           width: double.infinity,
                           child: Text(
-                            b['name'] as String? ?? '',
+                            b['isDraft'] == true
+                                ? '${b['name']} (draft)'
+                                : b['name'] as String? ?? '',
                             textAlign: TextAlign.center,
                           ),
                         ),

--- a/lib/web_tools/web_custom_block_service.dart
+++ b/lib/web_tools/web_custom_block_service.dart
@@ -1,5 +1,8 @@
+import 'dart:typed_data';
+
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_storage/firebase_storage.dart';
 import '../models/custom_block_models.dart';
 
 class WebCustomBlockService {
@@ -31,6 +34,69 @@ class WebCustomBlockService {
     if (data == null) return null;
     data['id'] = int.tryParse(doc.id) ?? 0;
     return CustomBlock.fromMap(data);
+  }
+
+  Future<void> saveCustomBlock(CustomBlock block,
+      {Uint8List? coverImageBytes}) async {
+    final user = FirebaseAuth.instance.currentUser;
+    if (user == null) {
+      throw FirebaseAuthException(
+          code: 'unauthenticated', message: 'User not signed in');
+    }
+
+    String? imageUrl;
+    if (coverImageBytes != null) {
+      final fileName =
+          '${user.uid}_${DateTime.now().millisecondsSinceEpoch}.jpg';
+      final ref =
+          FirebaseStorage.instance.ref().child('block_covers/$fileName');
+      final task = await ref.putData(
+        coverImageBytes,
+        SettableMetadata(contentType: 'image/jpeg'),
+      );
+      imageUrl = await task.ref.getDownloadURL();
+    } else {
+      imageUrl = block.coverImagePath;
+    }
+
+    final blockData = {
+      'name': block.name,
+      'numWeeks': block.numWeeks,
+      'daysPerWeek': block.daysPerWeek,
+      'isDraft': block.isDraft,
+      'coverImageUrl': imageUrl,
+      'ownerId': user.uid,
+      'source': 'web_custom_builder',
+      'workouts': block.workouts
+          .map((w) => {
+                'id': w.id,
+                'dayIndex': w.dayIndex,
+                'name': w.name,
+                'lifts': w.lifts
+                    .map((l) => {
+                          'name': l.name,
+                          'sets': l.sets,
+                          'repsPerSet': l.repsPerSet,
+                          'multiplier': l.multiplier,
+                          'isBodyweight': l.isBodyweight,
+                          'isDumbbellLift': l.isDumbbellLift,
+                        })
+                    .toList(),
+              })
+          .toList(),
+    };
+
+    await FirebaseFirestore.instance
+        .collection('users')
+        .doc(user.uid)
+        .collection('custom_blocks')
+        .doc(block.id.toString())
+        .set(blockData);
+
+    await FirebaseFirestore.instance
+        .collection('custom_blocks')
+        .doc(block.id.toString())
+        .set(blockData);
   }
 
   /// Creates a new block run for [block] and returns the run document ID.


### PR DESCRIPTION
## Summary
- allow passing an initial block into `POSSBlockBuilder`
- support editing existing blocks and saving drafts
- upload or keep existing cover image when saving blocks
- show draft status in custom block grid
- add a `saveCustomBlock` helper in `WebCustomBlockService`

## Testing
- `dart`/`flutter` commands unavailable in container

------
https://chatgpt.com/codex/tasks/task_e_685c628010748323a6dc96252756ea9c