### PR TITLE
Implement set entry workflow for web logging

### DIFF
--- a/lib/web_tools/web_custom_block_service.dart
+++ b/lib/web_tools/web_custom_block_service.dart
@@ -157,7 +157,11 @@ class WebCustomBlockService {
           'multiplier': lift.multiplier,
           'isBodyweight': lift.isBodyweight,
           'isDumbbellLift': lift.isDumbbellLift,
-          'completedSets': <int>[],
+          'entries': List.generate(
+              lift.sets, (s) => {'reps': 0, 'weight': 0.0}),
+          'liftWorkload': 0.0,
+          'liftScore': 0.0,
+          'liftReps': 0,
         });
       }
     }

--- a/lib/web_tools/web_workout_log.dart
+++ b/lib/web_tools/web_workout_log.dart
@@ -15,7 +15,11 @@ class WebWorkoutLog extends StatefulWidget {
 
 class _WebWorkoutLogState extends State<WebWorkoutLog> {
   late final WorkoutDraft workout;
-  final Map<int, Set<int>> _completed = {};
+
+  final Map<int, List<TextEditingController>> _repCtrls = {};
+  final Map<int, List<TextEditingController>> _weightCtrls = {};
+
+  final Map<int, List<Map<String, dynamic>>> _prevEntries = {};
 
   @override
   void initState() {
@@ -28,7 +32,7 @@ class _WebWorkoutLogState extends State<WebWorkoutLog> {
     final user = FirebaseAuth.instance.currentUser;
     if (user == null) return;
     for (int i = 0; i < workout.lifts.length; i++) {
-      final doc = await FirebaseFirestore.instance
+      final liftDoc = await FirebaseFirestore.instance
           .collection('users')
           .doc(user.uid)
           .collection('block_runs')
@@ -38,15 +42,90 @@ class _WebWorkoutLogState extends State<WebWorkoutLog> {
           .collection('lifts')
           .doc(i.toString())
           .get();
-      final List<dynamic> completed = doc.data()?['completedSets'] ?? [];
-      _completed[i] = Set<int>.from(completed);
+
+      final List<dynamic> entriesData = liftDoc.data()?['entries'] ?? [];
+      _repCtrls[i] = List.generate(workout.lifts[i].sets, (index) {
+        final ctrl = TextEditingController();
+        if (index < entriesData.length) {
+          final e = entriesData[index] as Map<String, dynamic>;
+          ctrl.text = e['reps']?.toString() ?? '';
+        }
+        return ctrl;
+      });
+      _weightCtrls[i] = List.generate(workout.lifts[i].sets, (index) {
+        final ctrl = TextEditingController();
+        if (index < entriesData.length) {
+          final e = entriesData[index] as Map<String, dynamic>;
+          final w = (e['weight'] as num?)?.toDouble();
+          if (w != null && w > 0) {
+            ctrl.text = w % 1 == 0 ? w.toInt().toString() : w.toString();
+          }
+        }
+        return ctrl;
+      });
+
+      _prevEntries[i] = await _getPreviousEntries(i);
     }
     if (mounted) setState(() {});
   }
 
-  Future<void> _toggleSet(int liftIndex, int set) async {
+  Future<List<Map<String, dynamic>>> _getPreviousEntries(int liftIndex) async {
+    final user = FirebaseAuth.instance.currentUser;
+    if (user == null) return [];
+
+    final runDoc = await FirebaseFirestore.instance
+        .collection('users')
+        .doc(user.uid)
+        .collection('block_runs')
+        .doc(widget.runId)
+        .get();
+
+    final currentRunNumber = (runDoc.data()?['runNumber'] as num?)?.toInt() ?? 1;
+
+    final prevRunSnap = await FirebaseFirestore.instance
+        .collection('users')
+        .doc(user.uid)
+        .collection('block_runs')
+        .where('blockName', isEqualTo: widget.block.name)
+        .where('runNumber', isLessThan: currentRunNumber)
+        .orderBy('runNumber', descending: true)
+        .limit(1)
+        .get();
+
+    if (prevRunSnap.docs.isEmpty) return [];
+
+    final prevRunId = prevRunSnap.docs.first.id;
+    final prevLiftDoc = await FirebaseFirestore.instance
+        .collection('users')
+        .doc(user.uid)
+        .collection('block_runs')
+        .doc(prevRunId)
+        .collection('workouts')
+        .doc(widget.workoutIndex.toString())
+        .collection('lifts')
+        .doc(liftIndex.toString())
+        .get();
+
+    final List<dynamic> prevData = prevLiftDoc.data()?['entries'] ?? [];
+    return prevData.cast<Map<String, dynamic>>();
+  }
+
+  Future<void> _saveLift(int liftIndex) async {
     final user = FirebaseAuth.instance.currentUser;
     if (user == null) return;
+
+    final reps = _repCtrls[liftIndex]!
+        .map((c) => int.tryParse(c.text) ?? 0)
+        .toList();
+    final weights = _weightCtrls[liftIndex]!
+        .map((c) => double.tryParse(c.text) ?? 0.0)
+        .toList();
+
+    final entries = <Map<String, dynamic>>[];
+    for (int i = 0; i < reps.length; i++) {
+      entries.add({'reps': reps[i], 'weight': weights[i]});
+    }
+
     final liftRef = FirebaseFirestore.instance
         .collection('users')
         .doc(user.uid)
@@ -56,21 +135,70 @@ class _WebWorkoutLogState extends State<WebWorkoutLog> {
         .doc(widget.workoutIndex.toString())
         .collection('lifts')
         .doc(liftIndex.toString());
-    final snap = await liftRef.get();
-    final List<dynamic> completed = snap.data()?['completedSets'] ?? [];
-    _completed[liftIndex] = Set<int>.from(completed);
-    if (_completed[liftIndex]!.contains(set)) {
-      await liftRef.update({
-        'completedSets': FieldValue.arrayRemove([set])
-      });
-      _completed[liftIndex]!.remove(set);
-    } else {
-      await liftRef.update({
-        'completedSets': FieldValue.arrayUnion([set])
-      });
-      _completed[liftIndex]!.add(set);
+
+    await liftRef.update({'entries': entries});
+
+    final liftDoc = await liftRef.get();
+    final data = liftDoc.data() ?? {};
+    final multiplier = (data['multiplier'] as num?)?.toDouble() ?? 1.0;
+    final isDumbbell = data['isDumbbellLift'] == true;
+    final isBodyweight = data['isBodyweight'] == true;
+    final scoreType = isBodyweight ? 'bodyweight' : 'multiplier';
+
+    final liftWorkload = getLiftWorkloadFromDb(entries,
+        isDumbbellLift: isDumbbell);
+    final liftScore = calculateLiftScoreFromEntries(entries, multiplier,
+        isDumbbellLift: isDumbbell, scoreType: scoreType);
+    final liftReps = getLiftRepsFromDb(entries, isDumbbellLift: isDumbbell);
+
+    await liftRef.update({
+      'liftWorkload': liftWorkload,
+      'liftScore': liftScore,
+      'liftReps': liftReps,
+    });
+
+    await _updateWorkoutTotals();
+  }
+
+  Future<void> _updateWorkoutTotals() async {
+    final user = FirebaseAuth.instance.currentUser;
+    if (user == null) return;
+
+    final workoutRef = FirebaseFirestore.instance
+        .collection('users')
+        .doc(user.uid)
+        .collection('block_runs')
+        .doc(widget.runId)
+        .collection('workouts')
+        .doc(widget.workoutIndex.toString());
+
+    final liftsSnap = await workoutRef.collection('lifts').get();
+
+    double totalWorkload = 0.0;
+    double totalScore = 0.0;
+
+    for (final doc in liftsSnap.docs) {
+      totalWorkload +=
+          (doc.data()['liftWorkload'] as num?)?.toDouble() ?? 0.0;
+      totalScore += (doc.data()['liftScore'] as num?)?.toDouble() ?? 0.0;
     }
-    setState(() {});
+
+    final avgScore = liftsSnap.docs.isNotEmpty
+        ? totalScore / liftsSnap.docs.length
+        : 0.0;
+
+    final totalsRef = FirebaseFirestore.instance
+        .collection('users')
+        .doc(user.uid)
+        .collection('block_runs')
+        .doc(widget.runId)
+        .collection('workout_totals')
+        .doc(widget.workoutIndex.toString());
+
+    await totalsRef.update({
+      'workoutWorkload': totalWorkload,
+      'workoutScore': avgScore,
+    });
   }
 
   @override
@@ -81,20 +209,52 @@ class _WebWorkoutLogState extends State<WebWorkoutLog> {
         itemCount: workout.lifts.length,
         itemBuilder: (context, index) {
           final lift = workout.lifts[index];
+          final repCtrls = _repCtrls[index] ?? [];
+          final weightCtrls = _weightCtrls[index] ?? [];
+          final prev = _prevEntries[index] ?? [];
+
           return Card(
             margin: const EdgeInsets.all(8),
             child: ExpansionTile(
               title: Text(lift.name),
-              children: List.generate(lift.sets, (set) {
-                final checked = _completed[index]?.contains(set) ?? false;
-                return ListTile(
-                  leading: Checkbox(
-                    value: checked,
-                    onChanged: (_) => _toggleSet(index, set),
-                  ),
-                  title: Text('Set ${set + 1} - ${lift.repsPerSet} reps'),
-                );
-              }),
+              children: [
+                ...List.generate(lift.sets, (set) {
+                  final prevEntry = set < prev.length ? prev[set] : null;
+                  return Padding(
+                    padding: const EdgeInsets.symmetric(
+                        horizontal: 16, vertical: 8),
+                    child: Row(
+                      children: [
+                        Text('Set ${set + 1}'),
+                        const SizedBox(width: 8),
+                        Expanded(
+                          child: TextField(
+                            controller: repCtrls[set],
+                            decoration:
+                                const InputDecoration(labelText: 'Reps'),
+                            keyboardType: TextInputType.number,
+                            onChanged: (_) => _saveLift(index),
+                          ),
+                        ),
+                        const SizedBox(width: 8),
+                        Expanded(
+                          child: TextField(
+                            controller: weightCtrls[set],
+                            decoration:
+                                const InputDecoration(labelText: 'Weight'),
+                            keyboardType: TextInputType.number,
+                            onChanged: (_) => _saveLift(index),
+                          ),
+                        ),
+                        const SizedBox(width: 8),
+                        if (prevEntry != null)
+                          Text(
+                              'Prev ${prevEntry['reps']} x ${prevEntry['weight'] ?? 0}'),
+                      ],
+                    ),
+                  );
+                }),
+              ],
             ),
           );
         },


### PR DESCRIPTION
## Summary
- add reps+weight entry tracking when starting a web block run
- update web workout log screen to handle per-set entries
- compute lift/workout totals using existing calculation utilities

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c666838ec8323b4484f7b00842b88