### PR TITLE
Implement block deletion on web

### DIFF
--- a/lib/web_tools/custom_blocks_screen.dart
+++ b/lib/web_tools/custom_blocks_screen.dart
@@ -65,6 +65,18 @@ class _CustomBlocksScreenState extends State<CustomBlocksScreen> {
     }
   }
 
+  Future<void> _deleteBlock(String id) async {
+    try {
+      await WebCustomBlockService().deleteCustomBlock(id);
+      await _loadBlocks();
+    } on FirebaseException catch (e) {
+      final reauthed = await promptReAuthIfNeeded(context, e);
+      if (reauthed) {
+        await _deleteBlock(id);
+      }
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     if (_loading) return const Center(child: CircularProgressIndicator());
@@ -110,9 +122,53 @@ class _CustomBlocksScreenState extends State<CustomBlocksScreen> {
                     context.go('/custom-blocks/$id');
                   }
                 },
-                onLongPress: () {
+                onLongPress: () async {
                   final id = b["id"].toString();
-                  _editBlock(id);
+                  final action = await showModalBottomSheet<String>(
+                    context: context,
+                    builder: (ctx) => SafeArea(
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          ListTile(
+                            leading: const Icon(Icons.edit),
+                            title: const Text('Edit'),
+                            onTap: () => Navigator.pop(ctx, 'edit'),
+                          ),
+                          ListTile(
+                            leading: const Icon(Icons.delete),
+                            title: const Text('Delete'),
+                            onTap: () => Navigator.pop(ctx, 'delete'),
+                          ),
+                        ],
+                      ),
+                    ),
+                  );
+                  if (action == 'edit') {
+                    _editBlock(id);
+                  } else if (action == 'delete') {
+                    final confirm = await showDialog<bool>(
+                      context: context,
+                      builder: (ctx) => AlertDialog(
+                        title: const Text('Delete block?'),
+                        content: const Text(
+                            'Are you sure you want to delete this block?'),
+                        actions: [
+                          TextButton(
+                            onPressed: () => Navigator.pop(ctx, false),
+                            child: const Text('Cancel'),
+                          ),
+                          TextButton(
+                            onPressed: () => Navigator.pop(ctx, true),
+                            child: const Text('Delete'),
+                          ),
+                        ],
+                      ),
+                    );
+                    if (confirm == true) {
+                      await _deleteBlock(id);
+                    }
+                  }
                 },
                 child: Card(
                   clipBehavior: Clip.antiAlias,

--- a/lib/web_tools/web_custom_block_service.dart
+++ b/lib/web_tools/web_custom_block_service.dart
@@ -249,4 +249,21 @@ class WebCustomBlockService {
       'workoutScore': avgScore,
     });
   }
+
+  Future<void> deleteCustomBlock(String id) async {
+    final user = FirebaseAuth.instance.currentUser;
+    if (user == null) return;
+
+    final userDoc =
+        FirebaseFirestore.instance.collection('users').doc(user.uid);
+    await userDoc.collection('custom_blocks').doc(id).delete();
+    await userDoc.collection('customBlockRefs').doc(id).delete();
+
+    final globalDoc =
+        FirebaseFirestore.instance.collection('custom_blocks').doc(id);
+    final snap = await globalDoc.get();
+    if (snap.exists && snap.data()?['ownerId'] == user.uid) {
+      await globalDoc.delete();
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- add `_deleteBlock` helper to CustomBlocksScreen
- allow delete/edit choice on long press
- add `deleteCustomBlock` to WebCustomBlockService

## Testing
- `dart format lib/web_tools/custom_blocks_screen.dart lib/web_tools/web_custom_block_service.dart` *(fails: `dart` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685c7a4dbe7c8323a01aa9a5f0471636