### PR TITLE
Fix web auth state listening

### DIFF
--- a/lib/web_tools/poss_home_page.dart
+++ b/lib/web_tools/poss_home_page.dart
@@ -17,14 +17,41 @@ import 'package:flutter/foundation.dart' show kIsWeb;
 
 Color? _lightGrey = Colors.grey[400];
 
-class POSSHomePage extends StatefulWidget {
+/// Entry widget that reacts to Firebase auth changes.
+/// When a user signs in or out the `StreamBuilder` rebuilds and shows the
+/// appropriate UI without requiring a manual page refresh.
+class POSSHomePage extends StatelessWidget {
   const POSSHomePage({super.key});
 
   @override
-  State<POSSHomePage> createState() => _POSSHomePageState();
+  Widget build(BuildContext context) {
+    return StreamBuilder<User?>(
+      stream: FirebaseAuth.instance.authStateChanges(),
+      builder: (context, snapshot) {
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return const Scaffold(body: Center(child: CircularProgressIndicator()));
+        } else if (snapshot.hasData) {
+          // Logged in: show the main POSS interface.
+          return const _POSSHomeView();
+        } else {
+          // Not logged in: present the sign in dialog. The empty Scaffold acts
+          // as a placeholder while the dialog is displayed.
+          Future.microtask(() => showWebSignInDialog(context));
+          return const Scaffold();
+        }
+      },
+    );
+  }
 }
 
-class _POSSHomePageState extends State<POSSHomePage> {
+class _POSSHomeView extends StatefulWidget {
+  const _POSSHomeView({super.key});
+
+  @override
+  State<_POSSHomeView> createState() => _POSSHomeViewState();
+}
+
+class _POSSHomeViewState extends State<_POSSHomeView> {
   bool _showGrid = false;
   bool _loading = true;
   StreamSubscription<User?>? _authSub;

--- a/lib/web_tools/web_sign_in_dialog.dart
+++ b/lib/web_tools/web_sign_in_dialog.dart
@@ -50,7 +50,8 @@ Future<bool> showWebSignInDialog(BuildContext context) async {
               }
               await _createUserProfileIfNeeded(cred.user!);
               success = true;
-              if (context.mounted) Navigator.pop(context);
+              // Close the dialog so the home page can react to the new auth state.
+              if (context.mounted) Navigator.of(context).pop();
             } catch (e) {
               if (context.mounted) {
                 ScaffoldMessenger.of(context)
@@ -67,7 +68,8 @@ Future<bool> showWebSignInDialog(BuildContext context) async {
               if (cred != null) {
                 await _createUserProfileIfNeeded(cred.user!);
                 success = true;
-                if (context.mounted) Navigator.pop(context);
+                // Close the dialog after a successful popup sign in.
+                if (context.mounted) Navigator.of(context).pop();
               }
             } catch (e) {
               if (context.mounted) {
@@ -95,7 +97,8 @@ Future<bool> showWebSignInDialog(BuildContext context) async {
                   await FirebaseAuth.instance.signInWithCredential(oauth);
               await _createUserProfileIfNeeded(userCred.user!);
               success = true;
-              if (context.mounted) Navigator.pop(context);
+              // Close the dialog once Apple sign in succeeds.
+              if (context.mounted) Navigator.of(context).pop();
             } catch (e) {
               if (context.mounted) {
                 ScaffoldMessenger.of(context)


### PR DESCRIPTION
## Summary
- rebuild POSS home page whenever a Firebase Auth state change occurs
- close web sign in dialog after successful login

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686591806a148323b7bc2c9b414faae7