### PR TITLE
Add debug log for WebBlockDashboard init

### DIFF
--- a/lib/web_tools/web_block_dashboard.dart
+++ b/lib/web_tools/web_block_dashboard.dart
@@ -32,6 +32,7 @@ class _WebBlockDashboardState extends State<WebBlockDashboard> {
   @override
   void initState() {
     super.initState();
+    debugPrint('[DEBUG] BlockDashboard opened with blockId = ${widget.block.id}');
     _runId = widget.runId;
     _loadRuns();
   }


### PR DESCRIPTION
## Summary
- add a debug print when `WebBlockDashboard` opens

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686596ae059083239565946b5906f374