### PR TITLE
Handle null user in _loadRuns

### DIFF
--- a/lib/web_tools/web_block_dashboard.dart
+++ b/lib/web_tools/web_block_dashboard.dart
@@ -94,7 +94,11 @@ class _WebBlockDashboardState extends State<WebBlockDashboard> {
 
   Future<void> _loadRuns() async {
     final user = FirebaseAuth.instance.currentUser;
-    if (user == null) return;
+    debugPrint('[DEBUG] _loadRuns → user = ${user?.uid}');
+    if (user == null) {
+      if (mounted) setState(() => _loadingRuns = false); // stop spinner
+      return; // skip Firestore query
+    }
 
     final snap = await FirebaseFirestore.instance
         .collection('users')


### PR DESCRIPTION
## Summary
- add debug log for user in `_loadRuns`
- stop spinner and return early when there is no current user

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865999c343483239408186e8368c3c8