### PR TITLE
Add schedule preview to web builder

### DIFF
--- a/lib/web_tools/web_custom_block_service.dart
+++ b/lib/web_tools/web_custom_block_service.dart
@@ -289,6 +289,18 @@ class WebCustomBlockService {
     }
   }
 
+  /// Public wrapper for [_generateWebWorkoutDistribution] so UI components
+  /// can preview schedules without duplicating the logic.
+  List<Map<String, dynamic>> previewDistribution(
+    List<CustomWorkout> workouts,
+    int weeks,
+    int daysPerWeek,
+    String scheduleType,
+  ) {
+    return _generateWebWorkoutDistribution(
+        workouts, weeks, daysPerWeek, scheduleType);
+  }
+
   /// Generates an ordered distribution of [workouts] for web-based blocks.
   ///
   /// The resulting list contains a map for each scheduled workout with the


### PR DESCRIPTION
## Summary
- enable schedule preview and scheduling options for POSS block builder
- expose `previewDistribution` in service for schedule previews

## Testing
- `dart format lib/web_tools/web_custom_block_service.dart lib/web_tools/poss_block_builder.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ab752aeb48323b1764f44918145ae