### PR TITLE
Add schedule preview button

### DIFF
--- a/lib/web_tools/poss_block_builder.dart
+++ b/lib/web_tools/poss_block_builder.dart
@@ -223,7 +223,7 @@ class _POSSBlockBuilderState extends State<POSSBlockBuilder> {
         _workouts.isEmpty) {
       return;
     }
-    final dist = WebCustomBlockService().previewDistribution(
+    final dist = WebCustomBlockService()._generateWebWorkoutDistribution(
       _workouts,
       _numWeeks!,
       _daysPerWeek!,
@@ -238,14 +238,13 @@ class _POSSBlockBuilderState extends State<POSSBlockBuilder> {
           child: ListView.builder(
             shrinkWrap: true,
             itemCount: dist.length,
-            itemBuilder: (context, index) {
-              final item = dist[index];
-              final w = item['workout'] as WorkoutDraft;
-              final week = item['week'] as int;
-              final day = (item['dayIndex'] as int) + 1;
+            itemBuilder: (_, i) {
+              final item = dist[i];
               return ListTile(
-                dense: true,
-                title: Text('Week $week, Day $day: ${w.name}'),
+                title: Text(
+                  'Week ${item['week']} – Day ${item['dayIndex'] + 1}: '
+                  '${(item['workout'] as WorkoutDraft).name}',
+                ),
               );
             },
           ),


### PR DESCRIPTION
## Summary
- generate schedule preview using `_generateWebWorkoutDistribution`
- show preview dialog from 'Preview Schedule' button

## Testing
- `flutter format lib/web_tools/poss_block_builder.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686acdcd25fc8323a5d061b1571a3903