### PR TITLE
Sync check-in privacy

### DIFF
--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -404,10 +404,10 @@ class _SettingsScreenState extends State<SettingsScreen> {
             activeColor: Colors.green,
             title: const Text('Show Check-In Stats', style: TextStyle(color: Colors.white)),
             value: showCheckInInfo,
-              onChanged: (val) {
-                setState(() => showCheckInInfo = val);
+            onChanged: (val) async {
+              setState(() => showCheckInInfo = val);
               _updatePrivacy('showCheckInInfo', val);
-              _updateAllCheckInsPublic(val);
+              await _updateAllCheckInsPublic(val);
             },
           ),
           const Divider(color: Colors.white54),
@@ -418,5 +418,4 @@ class _SettingsScreenState extends State<SettingsScreen> {
           ),
         ],
       ),
-    );
-  }}
+    );  }}


### PR DESCRIPTION
## Summary
- keep check-in timeline entry 'public' field in sync with "Show Check-In Stats"

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ed86fbce8832394de1cf6343b3b57