### PR TITLE
Ensure check-ins save public flag

### DIFF
--- a/lib/screens/add_check_in_screen.dart
+++ b/lib/screens/add_check_in_screen.dart
@@ -87,6 +87,7 @@ class _AddCheckInScreenState extends State<AddCheckInScreen> {
     final userId = FirebaseAuth.instance.currentUser!.uid;
     final userDoc = await FirebaseFirestore.instance.collection('users').doc(userId).get();
     final userData = userDoc.data() ?? {};
+    final bool isPublic = userData['showCheckInInfo'] ?? true;
     final now = DateTime.now();
     final monthKey = "${now.year}-${now.month.toString().padLeft(2, '0')}";
 
@@ -152,6 +153,7 @@ class _AddCheckInScreenState extends State<AddCheckInScreen> {
       "displayName": userData['displayName'] ?? 'Lifter',
       "title": userData['title'] ?? '',
       "profileImageUrl": userData['profileImageUrl'] ?? '',
+      "public": isPublic,
     });
 
     Navigator.pop(context, true); // Done!


### PR DESCRIPTION
## Summary
- reference user `showCheckInInfo` setting when creating a check‑in
- include `public` field in new check-in entries

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ed922c8cc8323b60f8d8621636e7a