### PR TITLE
Fix check-in visibility

### DIFF
--- a/lib/screens/public_profile_screen.dart
+++ b/lib/screens/public_profile_screen.dart
@@ -102,12 +102,18 @@ class _PublicProfileScreenState extends State<PublicProfileScreen> {
   }
 
   Future<void> _checkBeforeAfterAvailability() async {
-    final snap = await FirebaseFirestore.instance
+    Query<Map<String, dynamic>> query = FirebaseFirestore.instance
         .collection('users')
         .doc(widget.userId)
         .collection('timeline_entries')
-        .where('type', isEqualTo: 'checkin')
-        .get();
+        .where('type', isEqualTo: 'checkin');
+
+    final currentUserId = FirebaseAuth.instance.currentUser?.uid;
+    if (widget.userId != currentUserId) {
+      query = query.where('public', isEqualTo: true);
+    }
+
+    final snap = await query.get();
     final count = snap.docs.where((d) {
       final data = d.data();
       final urls = data['imageUrls'];

--- a/lib/widgets/checkin_graph.dart
+++ b/lib/widgets/checkin_graph.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'dart:math';
 
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 
 class CheckInGraph extends StatefulWidget {
   final String userId;
@@ -128,13 +129,18 @@ class _CheckInGraphState extends State<CheckInGraph> {
   }
 
   Future<Map<String, List<FlSpot>>> _fetchData() async {
-    final snap = await FirebaseFirestore.instance
+    final currentUser = FirebaseAuth.instance.currentUser?.uid;
+    Query<Map<String, dynamic>> query = FirebaseFirestore.instance
         .collection('users')
         .doc(widget.userId)
         .collection('timeline_entries')
-        .where('type', isEqualTo: 'checkin')
-        .orderBy('timestamp')
-        .get();
+        .where('type', isEqualTo: 'checkin');
+
+    if (widget.userId != currentUser) {
+      query = query.where('public', isEqualTo: true);
+    }
+
+    final snap = await query.orderBy('timestamp').get();
 
     final weight = <FlSpot>[];
     final bodyFat = <FlSpot>[];


### PR DESCRIPTION
## Summary
- show only public check-ins when viewing another user's profile
- restrict public profile before/after check query to public posts

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686eda36b0488323967f513a74e33778