### PR TITLE
Add back button on WebBlockDashboard

### DIFF
--- a/lib/web_tools/web_block_dashboard.dart
+++ b/lib/web_tools/web_block_dashboard.dart
@@ -9,6 +9,7 @@ import 'web_sign_in_dialog.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:go_router/go_router.dart';
 
 class WebBlockDashboard extends StatefulWidget {
   final CustomBlock block;
@@ -329,6 +330,10 @@ class _WebBlockDashboardState extends State<WebBlockDashboard> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => context.go('/poss'),
+        ),
         title: Text(widget.block.name),
         actions: [
           if (_runId != null)


### PR DESCRIPTION
## Summary
- add go_router import
- include a back button on the WebBlockDashboard app bar

## Testing
- `Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_e_6876c416f3488323812a00ac9c0e5125