### PR TITLE
Refactor WebLiftEntry controller flow

### DIFF
--- a/lib/web_tools/web_lift_entry.dart
+++ b/lib/web_tools/web_lift_entry.dart
@@ -14,6 +14,12 @@ class WebLiftEntry extends StatefulWidget {
   /// contain `reps` and `weight` keys.
   final List<Map<String, dynamic>> previousEntries;
 
+  /// Controllers for reps input fields, one per set.
+  final List<TextEditingController> repControllers;
+
+  /// Controllers for weight input fields, one per set.
+  final List<TextEditingController> weightControllers;
+
 
   /// Callback triggered whenever a field changes. Returns lists of reps and
   /// weights strings corresponding to each set.
@@ -23,6 +29,8 @@ class WebLiftEntry extends StatefulWidget {
     super.key,
     required this.liftIndex,
     required this.lift,
+    required this.repControllers,
+    required this.weightControllers,
     this.previousEntries = const [],
     this.onChanged,
   });
@@ -32,30 +40,11 @@ class WebLiftEntry extends StatefulWidget {
 }
 
 class _WebLiftEntryState extends State<WebLiftEntry> {
-  late final List<TextEditingController> _repCtrls;
-  late final List<TextEditingController> _weightCtrls;
-
-  @override
-  void initState() {
-    super.initState();
-    _repCtrls =
-        List.generate(widget.lift.sets, (_) => TextEditingController());
-    _weightCtrls =
-        List.generate(widget.lift.sets, (_) => TextEditingController());
-  }
-
-  @override
-  void dispose() {
-    for (final c in _repCtrls) c.dispose();
-    for (final c in _weightCtrls) c.dispose();
-    super.dispose();
-  }
-
   void _notifyChanged() {
     setState(() {});
     widget.onChanged?.call(
-      _repCtrls.map((c) => c.text).toList(),
-      _weightCtrls.map((c) => c.text).toList(),
+      widget.repControllers.map((c) => c.text).toList(),
+      widget.weightControllers.map((c) => c.text).toList(),
     );
   }
 
@@ -94,16 +83,16 @@ class _WebLiftEntryState extends State<WebLiftEntry> {
             : prevScore.toStringAsFixed(1))
         : '-';
 
-    final liftReps = getLiftReps(_repCtrls,
+    final liftReps = getLiftReps(widget.repControllers,
         isDumbbellLift: widget.lift.isDumbbellLift);
     final liftWorkload = getLiftWorkload(
-      _repCtrls,
-      _weightCtrls,
+      widget.repControllers,
+      widget.weightControllers,
       isDumbbellLift: widget.lift.isDumbbellLift,
     );
     final liftScore = getLiftScore(
-      _repCtrls,
-      _weightCtrls,
+      widget.repControllers,
+      widget.weightControllers,
       widget.lift.multiplier,
       isDumbbellLift: widget.lift.isDumbbellLift,
       scoreType: widget.lift.isBodyweight ? 'bodyweight' : 'default',
@@ -190,7 +179,7 @@ class _WebLiftEntryState extends State<WebLiftEntry> {
                     Padding(
                       padding: const EdgeInsets.all(8.0),
                       child: TextField(
-                        controller: _repCtrls[set],
+                        controller: widget.repControllers[set],
                         keyboardType: TextInputType.number,
                         onChanged: (_) => _notifyChanged(),
                         decoration: const InputDecoration(),
@@ -204,7 +193,7 @@ class _WebLiftEntryState extends State<WebLiftEntry> {
                     Padding(
                       padding: const EdgeInsets.all(8.0),
                       child: TextField(
-                        controller: _weightCtrls[set],
+                        controller: widget.weightControllers[set],
                         keyboardType: TextInputType.number,
                         onChanged: (_) => _notifyChanged(),
                         decoration: const InputDecoration(),

--- a/lib/web_tools/web_workout_log.dart
+++ b/lib/web_tools/web_workout_log.dart
@@ -310,19 +310,18 @@ class _WebWorkoutLogState extends State<WebWorkoutLog> {
             final lift = workout.lifts[index];
             final prev = _prevEntries[index] ?? [];
 
+            final repCtrls =
+                _repCtrls[index] ??= List.generate(lift.sets, (_) => TextEditingController());
+            final weightCtrls = _weightCtrls[index] ??=
+                List.generate(lift.sets, (_) => TextEditingController());
+
             return WebLiftEntry(
               liftIndex: index,
               lift: lift,
               previousEntries: prev,
-              onChanged: (reps, weights) {
-                final repCtrls = _repCtrls[index] ??=
-                    List.generate(lift.sets, (_) => TextEditingController());
-                final weightCtrls = _weightCtrls[index] ??=
-                    List.generate(lift.sets, (_) => TextEditingController());
-                for (var i = 0; i < lift.sets; i++) {
-                  repCtrls[i].text = reps[i];
-                  weightCtrls[i].text = weights[i];
-                }
+              repControllers: repCtrls,
+              weightControllers: weightCtrls,
+              onChanged: (_, __) {
                 _saveLift(index);
               },
             );


### PR DESCRIPTION
## Summary
- Let `WebLiftEntry` accept rep and weight TextEditingControllers from its parent instead of creating its own
- Remove internal controller creation and disposal
- Pass controllers from `WebWorkoutLog` directly into `WebLiftEntry`

## Testing
- `dart format lib/web_tools/web_lift_entry.dart lib/web_tools/web_workout_log.dart` *(fails: command not found)*
- `flutter format lib/web_tools/web_lift_entry.dart lib/web_tools/web_workout_log.dart` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68911f5e44148323b134e77d43bdb6d8