### PR TITLE
Fix previous workout data display

### DIFF
--- a/lib/web_tools/web_lift_entry.dart
+++ b/lib/web_tools/web_lift_entry.dart
@@ -179,8 +179,11 @@ class _WebLiftEntryState extends State<WebLiftEntry> {
               // Sets rows (7 columns)
               ...List.generate(widget.lift.sets, (set) {
                 final prevEntry = set < prev.length ? prev[set] : null;
-                final prevReps = prevEntry != null ? (prevEntry['prev']?.toString() ?? '') : '';
-                final prevWeightNum = prevEntry != null ? (prevEntry['lift'] as num?)?.toDouble() : null;
+                final prevSetReps =
+                    prevEntry != null ? (prevEntry['reps']?.toString() ?? '') : '';
+                final prevWeightNum = prevEntry != null
+                    ? (prevEntry['weight'] as num?)?.toDouble()
+                    : null;
                 String prevWeight = '';
                 if (prevWeightNum != null && prevWeightNum > 0) {
                   prevWeight = prevWeightNum % 1 == 0
@@ -228,7 +231,7 @@ class _WebLiftEntryState extends State<WebLiftEntry> {
                     ),
                     Padding(
                       padding: const EdgeInsets.all(8.0),
-                      child: Text(prevReps, textAlign: TextAlign.center),
+                      child: Text(prevSetReps, textAlign: TextAlign.center),
                     ),
                     Padding(
                       padding: const EdgeInsets.all(8.0),

--- a/lib/web_tools/web_workout_log.dart
+++ b/lib/web_tools/web_workout_log.dart
@@ -184,7 +184,19 @@ class _WebWorkoutLogState extends State<WebWorkoutLog> {
     prevLiftDoc ??= await liftsCol.doc(liftIndex.toString()).get();
 
     final List<dynamic> prevData = prevLiftDoc.data()?['entries'] ?? [];
-    return prevData.cast<Map<String, dynamic>>();
+    return prevData
+        .map<Map<String, dynamic>>((e) {
+          // Normalize legacy keys ('prev' and 'lift') to the current
+          // 'reps'/'weight' structure so older workout logs still display
+          // correctly in the UI.
+          if (e is Map<String, dynamic>) {
+            final reps = e['reps'] ?? e['prev'] ?? 0;
+            final weight = e['weight'] ?? e['lift'] ?? 0;
+            return {'reps': reps, 'weight': weight};
+          }
+          return {'reps': 0, 'weight': 0};
+        })
+        .toList();
   }
 
   void _recalculateTotals() {


### PR DESCRIPTION
## Summary
- Normalize legacy lift entry keys to `reps`/`weight` when loading prior workout data
- Read previous workout entries using updated keys so prior reps and weights appear in the log

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898c4a6362c8323a3f4b488fd94e71d