### PR TITLE
Fix previous data display in web workout log

### DIFF
--- a/lib/web_tools/web_lift_entry.dart
+++ b/lib/web_tools/web_lift_entry.dart
@@ -179,11 +179,22 @@ class _WebLiftEntryState extends State<WebLiftEntry> {
               // Sets rows (7 columns)
               ...List.generate(widget.lift.sets, (set) {
                 final prevEntry = set < prev.length ? prev[set] : null;
-                final prevSetReps =
-                    prevEntry != null ? (prevEntry['reps']?.toString() ?? '') : '';
-                final prevWeightNum = prevEntry != null
-                    ? (prevEntry['weight'] as num?)?.toDouble()
-                    : null;
+                String prevSetReps = '';
+                double? prevWeightNum;
+                if (prevEntry != null) {
+                  final r = prevEntry['reps'];
+                  if (r is num) {
+                    prevSetReps = r.toInt().toString();
+                  } else if (r is String) {
+                    prevSetReps = r;
+                  }
+                  final w = prevEntry['weight'];
+                  if (w is num) {
+                    prevWeightNum = w.toDouble();
+                  } else if (w is String) {
+                    prevWeightNum = double.tryParse(w);
+                  }
+                }
                 String prevWeight = '';
                 if (prevWeightNum != null && prevWeightNum > 0) {
                   prevWeight = prevWeightNum % 1 == 0


### PR DESCRIPTION
## Summary
- ensure web workout log finds previous workouts by scanning all workout docs and accepting both `name` and legacy `workoutName` fields
- convert stored reps and weight values to numbers before calculations and display
- handle string-based previous values in web lift entry so prior reps and weights appear correctly

## Testing
- `dart format lib/web_tools/web_lift_entry.dart lib/web_tools/web_workout_log.dart` *(fails: command not found)*
- `flutter analyze lib/web_tools/web_lift_entry.dart lib/web_tools/web_workout_log.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898ccf6ffcc83239b0ceba1b0b1708e