### PR TITLE
Store custom lift metadata per workout

### DIFF
--- a/lib/screens/workout_log.dart
+++ b/lib/screens/workout_log.dart
@@ -153,26 +153,23 @@ class WorkoutLogScreenState extends State<WorkoutLogScreen> with SingleTickerPro
     } else {
       final liftsFromDb = await db.getWorkoutLifts(widget.workoutInstanceId);
       for (final lift in liftsFromDb) {
-        final liftData = await db.getLiftById(lift['liftId']);
-        if (liftData != null) {
-          orderedLifts.add(
-            Liftinfo(
-              liftId: liftData['liftId'] as int,
-              workoutInstanceId: widget.workoutInstanceId,
-              liftName: liftData['liftName'] ?? 'Unknown',
-              repScheme: liftData['repScheme'] ?? '',
-              numSets: liftData['numSets'] ?? 3,
-              scoreMultiplier: (liftData['scoreMultiplier'] ?? 1.0).toDouble(),
-              isDumbbellLift: liftData['isDumbbellLift'] == 1,
-              scoreType: liftData['scoreType'] ?? 'multiplier',
-              youtubeUrl: liftData['youtubeUrl'],
-              description: liftData['description'] ?? '',
-              referenceLiftId: liftData['referenceLiftId'],
-              percentOfReference:
-              (liftData['percentOfReference'] as num?)?.toDouble(),
-            ),
-          );
-        }
+        orderedLifts.add(
+          Liftinfo(
+            liftId: lift['liftId'] as int,
+            workoutInstanceId: widget.workoutInstanceId,
+            liftName: lift['liftName'] ?? 'Unknown',
+            repScheme: lift['repScheme'] ?? '',
+            numSets: lift['numSets'] ?? 3,
+            scoreMultiplier: (lift['scoreMultiplier'] ?? 1.0).toDouble(),
+            isDumbbellLift: lift['isDumbbellLift'] == 1,
+            scoreType: lift['scoreType'] ?? 'multiplier',
+            youtubeUrl: lift['youtubeUrl'],
+            description: lift['description'] ?? '',
+            referenceLiftId: lift['referenceLiftId'],
+            percentOfReference:
+                (lift['percentOfReference'] as num?)?.toDouble(),
+          ),
+        );
       }
       workoutDefinition = {
         'workoutId': workoutId,


### PR DESCRIPTION
## Summary
- extend `lift_workouts` and `lift_drafts` tables to capture sets, reps, multipliers and bodyweight/dumbbell flags
- persist custom lift fields when creating blocks from custom templates
- load lifts for workout instances using stored metadata instead of default lift definitions
- update workout log to use stored lift details

## Testing
- `dart format lib/services/db_service.dart lib/screens/workout_log.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a38057ba3c8323be71dd48395e6a18