### PR TITLE
Retrieve custom workout lift settings

### DIFF
--- a/lib/screens/workout_log.dart
+++ b/lib/screens/workout_log.dart
@@ -153,15 +153,20 @@ class WorkoutLogScreenState extends State<WorkoutLogScreen> with SingleTickerPro
     } else {
       final liftsFromDb = await db.getWorkoutLifts(widget.workoutInstanceId);
       for (final lift in liftsFromDb) {
+        final int sets = (lift['sets'] as int?) ?? 3;
+        final int? repsPerSet = lift['repsPerSet'] as int?;
+        final repScheme = repsPerSet != null
+            ? '$sets sets x $repsPerSet reps'
+            : (lift['repScheme'] ?? '');
         orderedLifts.add(
           Liftinfo(
             liftId: lift['liftId'] as int,
             workoutInstanceId: widget.workoutInstanceId,
             liftName: lift['liftName'] ?? 'Unknown',
-            repScheme: lift['repScheme'] ?? '',
-            numSets: lift['numSets'] ?? 3,
-            scoreMultiplier: (lift['scoreMultiplier'] ?? 1.0).toDouble(),
-            isDumbbellLift: lift['isDumbbellLift'] == 1,
+            repScheme: repScheme,
+            numSets: sets,
+            scoreMultiplier: (lift['multiplier'] ?? 1.0).toDouble(),
+            isDumbbellLift: (lift['isDumbbellLift'] ?? 0) == 1,
             scoreType: lift['scoreType'] ?? 'multiplier',
             youtubeUrl: lift['youtubeUrl'],
             description: lift['description'] ?? '',

--- a/lib/services/db_service.dart
+++ b/lib/services/db_service.dart
@@ -425,14 +425,14 @@ class DBService {
       int workoutInstanceId) async {
     final db = await database;
     return await db.rawQuery('''
-      SELECT lw.liftId, l.liftName,
-             CASE WHEN lw.repsPerSet IS NOT NULL THEN
-               (lw.numSets || ' sets x ' || lw.repsPerSet || ' reps')
-             ELSE l.repScheme END AS repScheme,
-             lw.numSets,
-             COALESCE(lw.multiplier, l.scoreMultiplier) AS scoreMultiplier,
+      SELECT lw.liftId,
+             l.liftName,
+             COALESCE(lw.numSets, l.numSets) AS sets,
+             lw.repsPerSet,
+             COALESCE(lw.multiplier, l.scoreMultiplier) AS multiplier,
              COALESCE(lw.isDumbbellLift, l.isDumbbellLift) AS isDumbbellLift,
              CASE WHEN lw.isBodyweight = 1 THEN 'bodyweight' ELSE l.scoreType END AS scoreType,
+             l.repScheme,
              l.youtubeUrl,
              l.description,
              l.referenceLiftId,


### PR DESCRIPTION
## Summary
- fetch per-workout sets, repsPerSet, and multiplier in `DBService.getWorkoutLifts`
- build rep scheme strings dynamically in `WorkoutLog`

## Testing
- `dart format lib/services/db_service.dart lib/screens/workout_log.dart` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a38b5de9e08323a6d356b0be9fcc40