### PR TITLE
Center preview schedule button

### DIFF
--- a/lib/screens/custom_block_wizard.dart
+++ b/lib/screens/custom_block_wizard.dart
@@ -443,7 +443,7 @@ class _CustomBlockWizardState extends State<CustomBlockWizard> {
             content: workouts.isEmpty
                 ? const SizedBox.shrink()
                 : Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
+                    crossAxisAlignment: CrossAxisAlignment.center,
                     children: [
                       SizedBox(
                         height: 400,
@@ -464,13 +464,10 @@ class _CustomBlockWizardState extends State<CustomBlockWizard> {
                           showDumbbellOption: true,
                         ),
                       ),
-                      const SizedBox(height: 8),
-                      Align(
-                        alignment: Alignment.centerLeft,
-                        child: ElevatedButton(
-                          onPressed: _previewSchedule,
-                          child: const Text('Preview Schedule'),
-                        ),
+                      const SizedBox(height: 16),
+                      ElevatedButton(
+                        onPressed: _previewSchedule,
+                        child: const Text('Preview Schedule'),
                       ),
                     ],
                   ),

--- a/lib/screens/workout_builder.dart
+++ b/lib/screens/workout_builder.dart
@@ -213,6 +213,7 @@ class _WorkoutBuilderState extends State<WorkoutBuilder> {
   @override
   Widget build(BuildContext context) {
     return Column(
+      crossAxisAlignment: CrossAxisAlignment.center,
       children: [
         Padding(
           padding: const EdgeInsets.all(8.0),
@@ -259,12 +260,11 @@ class _WorkoutBuilderState extends State<WorkoutBuilder> {
           onPressed: _showAddLiftSheet,
           child: const Text('Add Lift'),
         ),
-        const SizedBox(height: 8),
+        const SizedBox(height: 16),
         ElevatedButton(
           onPressed: widget.onComplete,
           child: Text(widget.isLast ? 'Build Block' : 'Next Workout'),
         ),
-        const SizedBox(height: 8),
       ],
     );
   }


### PR DESCRIPTION
## Summary
- center align Preview Schedule button beneath Add Lift and Build Block actions
- evenly space workout action buttons for better layout

## Testing
- `flutter format lib/screens/workout_builder.dart lib/screens/custom_block_wizard.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3b5a1c2bc832387bedc7fa9424830