### PR TITLE
Expand custom block schedule generation

### DIFF
--- a/lib/screens/custom_block_wizard.dart
+++ b/lib/screens/custom_block_wizard.dart
@@ -189,25 +189,26 @@ class _CustomBlockWizardState extends State<CustomBlockWizard> {
   }
 
   Future<void> _finish() async {
-    final List<WorkoutDraft> allWorkouts = [
-      for (final w in workouts)
-        WorkoutDraft(
-          id: w.id,
-          dayIndex: w.dayIndex,
-          name: w.name,
-          lifts: [
-            for (final l in w.lifts)
-              LiftDraft(
-                name: l.name,
-                sets: l.sets,
-                repsPerSet: l.repsPerSet,
-                multiplier: l.multiplier,
-                isBodyweight: l.isBodyweight,
-                isDumbbellLift: l.isDumbbellLift,
-              ),
-          ],
-        )
-    ];
+    final int totalDays = numWeeks! * daysPerWeek!;
+    final List<WorkoutDraft> allWorkouts = List.generate(totalDays, (i) {
+      final template = workouts[i % workouts.length];
+      return WorkoutDraft(
+        id: template.id,
+        dayIndex: i,
+        name: template.name,
+        lifts: [
+          for (final l in template.lifts)
+            LiftDraft(
+              name: l.name,
+              sets: l.sets,
+              repsPerSet: l.repsPerSet,
+              multiplier: l.multiplier,
+              isBodyweight: l.isBodyweight,
+              isDumbbellLift: l.isDumbbellLift,
+            ),
+        ],
+      );
+    });
 
     final int id =
         widget.initialBlock?.id ?? DateTime.now().millisecondsSinceEpoch;

--- a/lib/services/db_service.dart
+++ b/lib/services/db_service.dart
@@ -752,7 +752,10 @@ class DBService {
       },
       conflictAlgorithm: ConflictAlgorithm.replace,
     );
-    for (final workout in block.workouts) {
+    // Workouts are expected to already be expanded for the full block run.
+    final expanded = List<WorkoutDraft>.from(block.workouts)
+      ..sort((a, b) => a.dayIndex.compareTo(b.dayIndex));
+    for (final workout in expanded) {
       await insertWorkoutDraft(workout, block.id);
     }
     return block.id;
@@ -887,7 +890,9 @@ class DBService {
     );
     await db
         .delete('workout_drafts', where: 'blockId = ?', whereArgs: [block.id]);
-    for (final w in block.workouts) {
+    final expanded = List<WorkoutDraft>.from(block.workouts)
+      ..sort((a, b) => a.dayIndex.compareTo(b.dayIndex));
+    for (final w in expanded) {
       await insertWorkoutDraft(w, block.id);
     }
   }


### PR DESCRIPTION
## Summary
- Expand custom block wizard finish step to replicate workouts across all weeks/days with sequential day indexes
- Adjust DBService to accept expanded workout lists and persist them in order

## Testing
- `dart format lib/screens/custom_block_wizard.dart lib/services/db_service.dart` *(fails: command not found)*
- `flutter format lib/screens/custom_block_wizard.dart lib/services/db_service.dart` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3d32f27fc8323a059b5134bc1751c