### PR TITLE
Use unique IDs for custom block workouts

### DIFF
--- a/lib/models/custom_block_models.dart
+++ b/lib/models/custom_block_models.dart
@@ -45,6 +45,7 @@ class CustomBlock {
               isDumbbellLift: l['isDumbbellLift'] ?? false,
             );
           }).toList(),
+          isPersisted: true,
         );
       }).toList(),
     );
@@ -56,11 +57,13 @@ class WorkoutDraft {
   int dayIndex;
   String name;
   List<LiftDraft> lifts;
+  bool isPersisted;
   WorkoutDraft({
     required this.id,
     required this.dayIndex,
     required this.name,
     required this.lifts,
+    this.isPersisted = true,
   });
 }
 

--- a/lib/screens/custom_block_wizard.dart
+++ b/lib/screens/custom_block_wizard.dart
@@ -65,6 +65,7 @@ class _CustomBlockWizardState extends State<CustomBlockWizard> {
                       ),
                     )
                     .toList(),
+                isPersisted: true,
               ))
           .toList();
       _coverImagePath = block.coverImagePath;
@@ -80,10 +81,16 @@ class _CustomBlockWizardState extends State<CustomBlockWizard> {
 
   void _initializeWorkouts() {
     final count = _uniqueCount ?? 0;
+    final baseId = DateTime.now().millisecondsSinceEpoch;
     workouts = List.generate(
       count,
-      (i) =>
-          WorkoutDraft(id: i, dayIndex: i, name: 'Workout ${i + 1}', lifts: []),
+      (i) => WorkoutDraft(
+        id: baseId + i,
+        dayIndex: i,
+        name: 'Workout ${i + 1}',
+        lifts: [],
+        isPersisted: false,
+      ),
     );
   }
 
@@ -194,10 +201,11 @@ class _CustomBlockWizardState extends State<CustomBlockWizard> {
 
   Future<void> _finish() async {
     final int totalDays = numWeeks! * daysPerWeek!;
+    final baseId = DateTime.now().millisecondsSinceEpoch;
     final List<WorkoutDraft> allWorkouts = List.generate(totalDays, (i) {
       final template = workouts[i % workouts.length];
       return WorkoutDraft(
-        id: template.id,
+        id: baseId + i,
         dayIndex: i,
         name: template.name,
         lifts: [
@@ -211,6 +219,7 @@ class _CustomBlockWizardState extends State<CustomBlockWizard> {
               isDumbbellLift: l.isDumbbellLift,
             ),
         ],
+        isPersisted: false,
       );
     });
 

--- a/lib/screens/workout_builder.dart
+++ b/lib/screens/workout_builder.dart
@@ -55,12 +55,14 @@ class _WorkoutBuilderState extends State<WorkoutBuilder> {
   }
 
   Future<void> _loadWorkoutFromDb() async {
+    if (!widget.workout.isPersisted) return;
     final fetched = await DBService().fetchWorkoutDraft(widget.workout.id);
     if (fetched != null && mounted) {
       setState(() {
         widget.workout
           ..name = fetched.name
-          ..dayIndex = fetched.dayIndex;
+          ..dayIndex = fetched.dayIndex
+          ..isPersisted = true;
         widget.workout.lifts
           ..clear()
           ..addAll(fetched.lifts);

--- a/lib/services/db_service.dart
+++ b/lib/services/db_service.dart
@@ -763,11 +763,16 @@ class DBService {
 
   Future<void> insertWorkoutDraft(WorkoutDraft w, int blockId) async {
     final db = await database;
-    final workoutId = await db.insert('workout_drafts', {
-      'blockId': blockId,
-      'dayIndex': w.dayIndex,
-      'name': w.name,
-    });
+    final workoutId = await db.insert(
+      'workout_drafts',
+      {
+        'id': w.id,
+        'blockId': blockId,
+        'dayIndex': w.dayIndex,
+        'name': w.name,
+      },
+      conflictAlgorithm: ConflictAlgorithm.replace,
+    );
     for (final lift in w.lifts) {
       await db.insert('lift_drafts', {
         'workoutId': workoutId,
@@ -808,6 +813,7 @@ class DBService {
       dayIndex: w['dayIndex'] as int,
       name: w['name'] as String? ?? '',
       lifts: lifts,
+      isPersisted: true,
     );
   }
 
@@ -942,6 +948,7 @@ class DBService {
                     isDumbbellLift: (l['isDumbbellLift'] as int) == 1,
                   ))
               .toList(),
+          isPersisted: true,
         ),
 
       );

--- a/lib/web_tools/poss_block_builder.dart
+++ b/lib/web_tools/poss_block_builder.dart
@@ -74,6 +74,7 @@ class _POSSBlockBuilderState extends State<POSSBlockBuilder> {
             ),
           )
               .toList(),
+          isPersisted: true,
         ),
       )
           .toList();
@@ -99,13 +100,15 @@ class _POSSBlockBuilderState extends State<POSSBlockBuilder> {
 
   void _initializeWorkouts() {
     final count = _uniqueCount ?? 0;
+    final baseId = DateTime.now().millisecondsSinceEpoch;
     _workouts = List.generate(
       count,
       (i) => CustomWorkout(
-        id: i,
+        id: baseId + i,
         name: 'Workout ${i + 1}',
         dayIndex: i,
         lifts: [],
+        isPersisted: false,
       ),
     );
   }
@@ -309,6 +312,7 @@ class _POSSBlockBuilderState extends State<POSSBlockBuilder> {
                 isDumbbellLift: l.isDumbbellLift,
               ),
           ],
+          isPersisted: false,
         )
     ];
 


### PR DESCRIPTION
## Summary
- generate timestamp-based IDs for new workouts in custom block wizard and final block
- track whether WorkoutDrafts are persisted to skip loading unsaved workouts
- insert workouts into the database using provided IDs

## Testing
- `dart format lib/models/custom_block_models.dart lib/screens/custom_block_wizard.dart lib/screens/workout_builder.dart lib/services/db_service.dart lib/web_tools/poss_block_builder.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a46f934fa08323afff22ccbed85d0d