### PR TITLE
Fix duplicate workouts in custom block wizard

### DIFF
--- a/lib/screens/custom_block_wizard.dart
+++ b/lib/screens/custom_block_wizard.dart
@@ -45,8 +45,21 @@ class _CustomBlockWizardState extends State<CustomBlockWizard> {
       // Only include the first instance of each workout when editing.
       // This allows the user to edit one week and have the changes
       // applied across all repeated weeks when the block is saved.
-      final firstWeekWorkouts =
-          block.workouts.where((w) => w.dayIndex < block.daysPerWeek).toList();
+      final seenIds = <int>{};
+      final seenNames = <String>{};
+      final firstWeekWorkouts = block.workouts.where((w) {
+        final isFirstWeek = w.dayIndex < block.daysPerWeek;
+        final alreadySeen =
+            seenIds.contains(w.id) || seenNames.contains(w.name);
+        if (isFirstWeek && !alreadySeen) {
+          seenIds.add(w.id);
+          seenNames.add(w.name);
+          return true;
+        }
+        return false;
+      }).toList();
+
+      _uniqueCount = firstWeekWorkouts.length;
 
       workouts = firstWeekWorkouts
           .map((w) => WorkoutDraft(


### PR DESCRIPTION
## Summary
- Avoid duplicates when loading existing custom block workouts by tracking seen IDs/names
- Set `_uniqueCount` to the number of unique workouts for consistent navigation

## Testing
- `dart format lib/screens/custom_block_wizard.dart` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a48d3c417c8323922c71535fe7f70b