### PR TITLE
Ensure active block instances reflect custom block edits

### DIFF
--- a/lib/screens/custom_block_wizard.dart
+++ b/lib/screens/custom_block_wizard.dart
@@ -275,7 +275,10 @@ class _CustomBlockWizardState extends State<CustomBlockWizard> {
     if (inst.isEmpty) return;
 
     final activeName = inst.first['blockName']?.toString();
-    if (activeName != block.name) return;
+    final initialName = widget.initialBlock?.name;
+    // Ensure we update the active instance if its name matches either the
+    // edited block's new name or the original name prior to editing.
+    if (activeName != block.name && activeName != initialName) return;
 
     await DBService().applyCustomBlockEdits(block.id, blockInstanceId);
   }


### PR DESCRIPTION
## Summary
- Update wizard to apply edits when active instance matches old or new block name
- Refresh active block instance with new block ID/name when custom block is edited

## Testing
- `dart format lib/screens/custom_block_wizard.dart lib/services/db_service.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4fce3a3108323910b87e99c1d2bb0