### PR TITLE
Remove custom block draft workflow

### DIFF
--- a/lib/screens/custom_block_wizard.dart
+++ b/lib/screens/custom_block_wizard.dart
@@ -134,40 +134,6 @@ class _CustomBlockWizardState extends State<CustomBlockWizard> {
     });
   }
 
-  Future<void> _saveDraft() async {
-    if (blockName.trim().isEmpty) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Please enter a block name')),
-      );
-      return;
-    }
-    if (workouts.isEmpty && (_uniqueCount ?? 0) > 0) {
-      _initializeWorkouts();
-    }
-    final int id =
-        widget.initialBlock?.id ?? DateTime.now().millisecondsSinceEpoch;
-    final block = CustomBlock(
-      id: id,
-      name: blockName,
-      numWeeks: numWeeks ?? 1,
-      daysPerWeek: daysPerWeek ?? 1,
-      coverImagePath: _coverImagePath ?? 'assets/logo25.jpg',
-      workouts: workouts,
-      isDraft: true,
-      scheduleType: _scheduleType,
-    );
-    if (widget.initialBlock != null) {
-      await DBService().updateCustomBlock(block);
-    } else {
-      await DBService().insertCustomBlock(block);
-    }
-
-    // If this block is currently active, refresh the instance so future
-    // workouts use the updated data.
-    await _applyEditsToActiveInstance(block);
-    if (mounted) Navigator.pop(context);
-  }
-
   Future<void> _previewSchedule() async {
     if (numWeeks == null || daysPerWeek == null || workouts.isEmpty) return;
 
@@ -287,8 +253,6 @@ class _CustomBlockWizardState extends State<CustomBlockWizard> {
     final user = FirebaseAuth.instance.currentUser;
     if (user == null) return;
 
-    if (block.isDraft) return;
-
     String? imageUrl;
     if (block.coverImagePath != null &&
         !block.coverImagePath!.startsWith('assets/')) {
@@ -351,13 +315,6 @@ class _CustomBlockWizardState extends State<CustomBlockWizard> {
     return Scaffold(
       appBar: AppBar(
         title: const Text('Custom Block'),
-        actions: [
-          if (_currentStep > 0)
-            IconButton(
-              icon: const Icon(Icons.save),
-              onPressed: _saveDraft,
-            ),
-        ],
       ),
       body: Stepper(
         currentStep: _currentStep,

--- a/lib/screens/user_dashboard.dart
+++ b/lib/screens/user_dashboard.dart
@@ -67,13 +67,11 @@ class _UserDashboardState extends State<UserDashboard> {
   Future<void> _fetchCustomBlocks() async {
     final db = DBService();
     await db.syncCustomBlocksFromFirestore();
-    final blocks = await db.getCustomBlocks(includeDrafts: true);
+    final blocks = await db.getCustomBlocks();
     if (!mounted) return;
     setState(() {
-      customBlockNames = blocks
-          .map((b) =>
-              b['isDraft'] == 1 ? "${b['name']} (draft)" : b['name'].toString())
-          .toList();
+      customBlockNames =
+          blocks.map((b) => b['name'].toString()).toList();
       customBlockIds = blocks.map<int>((b) => b['id'] as int).toList();
       customBlockImages = blocks
           .map<String>(

--- a/lib/web_tools/poss_block_builder.dart
+++ b/lib/web_tools/poss_block_builder.dart
@@ -113,49 +113,6 @@ class _POSSBlockBuilderState extends State<POSSBlockBuilder> {
     );
   }
 
-  Future<void> _saveDraft() async {
-    final blockName = _nameCtrl.text.trim();
-    if (blockName.isEmpty) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Please enter a block name')),
-      );
-      return;
-    }
-    if (_workouts.isEmpty && (_daysPerWeek ?? 0) > 0) {
-      _initializeWorkouts();
-    }
-    final int id =
-        widget.initialBlock?.id ?? DateTime.now().millisecondsSinceEpoch;
-    final block = CustomBlock(
-      id: id,
-      name: blockName,
-      numWeeks: _numWeeks ?? 1,
-      daysPerWeek: _daysPerWeek ?? 1,
-      scheduleType: _scheduleType,
-      coverImagePath: _coverImageUrl,
-      workouts: _workouts,
-      isDraft: true,
-    );
-    try {
-      await WebCustomBlockService()
-          .saveCustomBlock(block, coverImageBytes: _coverImageBytes);
-      if (mounted) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(const SnackBar(content: Text('Draft saved')));
-        Navigator.pop(context);
-      }
-      widget.onSaved?.call();
-    } on FirebaseException catch (e) {
-      final reauthed = await promptReAuthIfNeeded(context, e);
-      if (reauthed) {
-        await WebCustomBlockService()
-            .saveCustomBlock(block, coverImageBytes: _coverImageBytes);
-      } else {
-        return;
-      }
-    }
-  }
-
   Future<void> _saveBlockToFirestore(CustomBlock block) async {
     String? imageUrl;
     final user = FirebaseAuth.instance.currentUser;
@@ -409,13 +366,6 @@ class _POSSBlockBuilderState extends State<POSSBlockBuilder> {
         appBar: AppBar(
           foregroundColor: _lightGrey,
           title: const Text('Training Block Builder'),
-          actions: [
-            if (_currentStep > 0)
-              IconButton(
-                icon: const Icon(Icons.save),
-                onPressed: _saveDraft,
-              ),
-          ],
         ),
         drawer: const POSSDrawer(),
         body: SingleChildScrollView(

--- a/lib/widgets/block_grid_section.dart
+++ b/lib/widgets/block_grid_section.dart
@@ -47,9 +47,7 @@ class BlockGridSection extends StatelessWidget {
       ),
       itemBuilder: (context, index) {
         String blockName = blockNames[index];
-        final cleanName = blockName.replaceAll(' (draft)', '');
-        int? blockInstanceId =
-            blockInstances[blockName] ?? blockInstances[cleanName];
+        int? blockInstanceId = blockInstances[blockName];
         final path = workoutImages[index];
         final isAsset = path.startsWith('assets/');
         final isNetwork = path.startsWith('http');
@@ -67,7 +65,7 @@ class BlockGridSection extends StatelessWidget {
 
             if (blockInstanceId == null) {
               int newId = await db.insertNewBlockInstance(blockName, user.uid);
-              onNewBlockInstanceCreated(cleanName, newId);
+              onNewBlockInstanceCreated(blockName, newId);
               blockInstanceId = newId;
             }
 


### PR DESCRIPTION
## Summary
- remove draft save flow from custom block creation
- refresh active block instances using the final name
- simplify custom block retrieval and instance creation

## Testing
- `dart format lib/widgets/block_grid_section.dart lib/screens/custom_block_wizard.dart lib/screens/user_dashboard.dart lib/services/db_service.dart lib/web_tools/poss_block_builder.dart` *(fails: command not found)*
- `flutter format lib/widgets/block_grid_section.dart lib/screens/custom_block_wizard.dart lib/screens/user_dashboard.dart lib/services/db_service.dart lib/web_tools/poss_block_builder.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a52c1870a4832385650bdd777e1cdd