### PR TITLE
Track custom block IDs on block instances

### DIFF
--- a/lib/screens/custom_block_wizard.dart
+++ b/lib/screens/custom_block_wizard.dart
@@ -239,12 +239,8 @@ class _CustomBlockWizardState extends State<CustomBlockWizard> {
     final inst = await db.query('block_instances',
         where: 'blockInstanceId = ?', whereArgs: [blockInstanceId], limit: 1);
     if (inst.isEmpty) return;
-
-    final activeName = inst.first['blockName']?.toString();
-    final initialName = widget.initialBlock?.name;
-    // Ensure we update the active instance if its name matches either the
-    // edited block's new name or the original name prior to editing.
-    if (activeName != block.name && activeName != initialName) return;
+    final activeCustomId = inst.first['customBlockId'] as int?;
+    if (activeCustomId != block.id) return;
 
     await DBService().applyCustomBlockEdits(block.id, blockInstanceId);
   }


### PR DESCRIPTION
## Summary
- Add `customBlockId` column to `block_instances` and bump DB version
- Populate `customBlockId` when creating instances from custom blocks
- Use `customBlockId` to apply custom block edits and migrate existing data

## Testing
- `flutter analyze` *(fails: command not found)*
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a608ae54748323a7cf1dcfa3c6d843