### PR TITLE
Avoid creating block instance when editing block

### DIFF
--- a/lib/screens/custom_block_wizard.dart
+++ b/lib/screens/custom_block_wizard.dart
@@ -225,20 +225,24 @@ class _CustomBlockWizardState extends State<CustomBlockWizard> {
     await _uploadBlockToFirestore(block);
     final user = FirebaseAuth.instance.currentUser;
     if (user != null) {
-      int blockInstanceId;
-      if (existingInstanceId != null) {
-        blockInstanceId = existingInstanceId;
-      } else {
-        blockInstanceId =
-            await DBService().insertNewBlockInstance(block.name, user.uid);
-        await DBService().activateBlockInstanceIfNeeded(
-            blockInstanceId, user.uid, block.name);
+      int? blockInstanceId = existingInstanceId;
+      if (blockInstanceId == null) {
+        if (widget.initialBlock == null) {
+          blockInstanceId = await DBService()
+              .insertNewBlockInstance(block.name, user.uid);
+          await DBService().activateBlockInstanceIfNeeded(
+              blockInstanceId, user.uid, block.name);
+        } else {
+          if (mounted) Navigator.pop(context);
+          return;
+        }
       }
       if (!mounted) return;
       Navigator.pushReplacement(
         context,
         MaterialPageRoute(
-          builder: (_) => BlockDashboard(blockInstanceId: blockInstanceId),
+          builder: (_) =>
+              BlockDashboard(blockInstanceId: blockInstanceId!),
         ),
       );
     } else {


### PR DESCRIPTION
## Summary
- Create new block instances only when building a new custom block
- When editing a block with no active instance, simply return to previous screen
- Launch BlockDashboard only when a block instance is available

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac6cb9a3e8832395429eb8617f29d8