### PR TITLE
fix: avoid duplicate custom block run on edit

### DIFF
--- a/lib/screens/custom_block_wizard.dart
+++ b/lib/screens/custom_block_wizard.dart
@@ -264,13 +264,18 @@ class _CustomBlockWizardState extends State<CustomBlockWizard> {
 
     final activeCustomId = inst.first['customBlockId'] as int?;
     final activeBlockName = inst.first['blockName'] as String?;
+    final prevBlockName = widget.initialBlock?.name;
 
+    // If this block instance is already linked by id, apply edits directly.
     if (activeCustomId == block.id) {
       await DBService().applyCustomBlockEdits(block.id, blockInstanceId);
       return blockInstanceId;
     }
 
-    if (activeBlockName == block.name) {
+    // Allow matching on either the new or previous name in case the block was
+    // renamed or the instance wasn't yet linked to a customBlockId.
+    if (activeBlockName == block.name ||
+        (prevBlockName != null && activeBlockName == prevBlockName)) {
       await DBService().applyCustomBlockEdits(block.id, blockInstanceId);
       await db.update('block_instances', {
         'customBlockId': block.id,


### PR DESCRIPTION
## Summary
- prevent new block instance from being created when editing a custom block
- reapply edits to existing run by matching previous block name

## Testing
- `dart format lib/screens/custom_block_wizard.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68acc6b83f8c83238b275c2d66ba747a