### PR TITLE
fix: correct save error message for lifts

### DIFF
--- a/lib/screens/workout_builder.dart
+++ b/lib/screens/workout_builder.dart
@@ -403,7 +403,7 @@ class _WorkoutBuilderState extends State<WorkoutBuilder> {
                         } catch (e) {
                           if (!mounted) return;
                           ScaffoldMessenger.of(context).showSnackBar(
-                            const SnackBar(content: Text('Failed to delete lift')),
+                            const SnackBar(content: Text('Failed to save lift')),
                           );
                         }
                       },


### PR DESCRIPTION
## Summary
- fix snackbar to show "Failed to save lift" when save action errors in workout builder

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad1a3538608323abd3b16e8db06af6