### PR TITLE
Ensure instance tables include slot and archive fields

### DIFF
--- a/lib/services/db_service.dart
+++ b/lib/services/db_service.dart
@@ -30,7 +30,16 @@ class DBService {
   // ──────────────────────────────────────────────────────────
   // 🔄 DATABASE INIT (v18, cleaned up)
   // ──────────────────────────────────────────────────────────
-  static const _dbVersion = 21;   // bump any time the schema changes
+  static const _dbVersion = 22;   // bump any time the schema changes
+
+  Future<bool> _hasColumn(DatabaseExecutor db, String table, String col) async {
+    final rows = await db.rawQuery('PRAGMA table_info($table);');
+    for (final r in rows) {
+      final name = (r['name'] as String?)?.toLowerCase();
+      if (name == col.toLowerCase()) return true;
+    }
+    return false;
+  }
 
   Future<Database> _initDatabase() async {
     final dbPath = await getDatabasesPath();
@@ -148,6 +157,29 @@ class DBService {
 
         await db.execute('PRAGMA foreign_keys = ON;');
         }
+
+        if (oldV < 22) {
+          try {
+            if (!await _hasColumn(db, 'workout_instances', 'slotIndex')) {
+              await db.execute(
+                  'ALTER TABLE workout_instances ADD COLUMN slotIndex INTEGER;');
+            }
+          } catch (_) {}
+
+          try {
+            if (!await _hasColumn(db, 'lift_instances', 'position')) {
+              await db.execute(
+                  'ALTER TABLE lift_instances ADD COLUMN position INTEGER DEFAULT 0;');
+            }
+          } catch (_) {}
+
+          try {
+            if (!await _hasColumn(db, 'lift_instances', 'archived')) {
+              await db.execute(
+                  'ALTER TABLE lift_instances ADD COLUMN archived INTEGER DEFAULT 0;');
+            }
+          } catch (_) {}
+        }
       },
     );
   }
@@ -223,6 +255,7 @@ class DBService {
         workoutName       TEXT,
         blockName         TEXT,
         week              INTEGER,
+        slotIndex         INTEGER,
         scheduledDate     TEXT,    -- NEW v16
         startTime         TEXT,
         endTime           TEXT,
@@ -1002,6 +1035,57 @@ class DBService {
     }
   }
 
+  Future<void> _resizeEntriesForLiftInstanceTx(
+      dynamic db, // Database or Transaction
+      int liftInstanceId,
+      int newSetCount,
+      ) async {
+    final rows = await db.query(
+      'lift_entries',
+      where: 'liftInstanceId = ?',
+      whereArgs: [liftInstanceId],
+      orderBy: 'setIndex ASC',
+    );
+
+    int? workoutInstanceId;
+    int? liftId;
+    if (rows.isNotEmpty) {
+      workoutInstanceId = (rows.first['workoutInstanceId'] as num?)?.toInt();
+      liftId = (rows.first['liftId'] as num?)?.toInt();
+    } else {
+      final li = await db.query(
+        'lift_instances',
+        columns: ['workoutInstanceId'],
+        where: 'liftInstanceId = ?',
+        whereArgs: [liftInstanceId],
+        limit: 1,
+      );
+      if (li.isNotEmpty) {
+        workoutInstanceId = (li.first['workoutInstanceId'] as num?)?.toInt();
+      }
+    }
+
+    final current = rows.length;
+    if (current > newSetCount) {
+      await db.delete(
+        'lift_entries',
+        where: 'liftInstanceId = ? AND setIndex > ?',
+        whereArgs: [liftInstanceId, newSetCount],
+      );
+    } else if (current < newSetCount) {
+      for (int i = current + 1; i <= newSetCount; i++) {
+        await db.insert('lift_entries', {
+          'liftInstanceId': liftInstanceId,
+          if (workoutInstanceId != null) 'workoutInstanceId': workoutInstanceId,
+          if (liftId != null) 'liftId': liftId,
+          'setIndex': i,
+          'reps': 0,
+          'weight': 0.0,
+        });
+      }
+    }
+  }
+
   /// Loads a single [WorkoutDraft] with its associated lifts from the database.
   Future<WorkoutDraft?> fetchWorkoutDraft(int workoutId) async {
     final db = await database;
@@ -1491,16 +1575,6 @@ class DBService {
     if (customBlock == null || customBlock.workouts.isEmpty) return;
 
     await db.transaction((txn) async {
-      // Utility: does a column exist on this table?
-      Future<bool> hasColumn(String table, String col) async {
-        final rows = await txn.rawQuery('PRAGMA table_info($table);');
-        for (final r in rows) {
-          final name = (r['name'] as String?)?.toLowerCase();
-          if (name == col.toLowerCase()) return true;
-        }
-        return false;
-      }
-
       // Ensure instance exists
       final instanceRows = await txn.query(
         'block_instances',
@@ -1523,10 +1597,10 @@ class DBService {
       );
 
       // Figure out optional columns once
-      final hasDayIndex    = await hasColumn('workout_instances', 'dayIndex');
-      final hasPosCol      = await hasColumn('lift_instances', 'position');
-      final hasArchivedWi  = await hasColumn('workout_instances', 'archived');
-      final hasArchivedLi  = await hasColumn('lift_instances', 'archived');
+      final hasDayIndex    = await _hasColumn(txn, 'workout_instances', 'dayIndex');
+      final hasPosCol      = await _hasColumn(txn, 'lift_instances', 'position');
+      final hasArchivedWi  = await _hasColumn(txn, 'workout_instances', 'archived');
+      final hasArchivedLi  = await _hasColumn(txn, 'lift_instances', 'archived');
 
       // Helpers
       Future<List<Map<String, Object?>>> workoutInstances() => txn.query(
@@ -1648,7 +1722,8 @@ class DBService {
             };
             if (hasPosCol) ins['position'] = j;
 
-            await txn.insert('lift_instances', ins);
+            final newLid = await txn.insert('lift_instances', ins);
+            await _resizeEntriesForLiftInstanceTx(txn, newLid, dl.sets);
           } else {
             final lid = match['liftInstanceId'] as int;
             final upd = <String, Object?>{
@@ -1667,6 +1742,7 @@ class DBService {
               where: 'liftInstanceId = ?',
               whereArgs: [lid],
             );
+            await _resizeEntriesForLiftInstanceTx(txn, lid, dl.sets);
           }
         }
 
@@ -1993,10 +2069,12 @@ class DBService {
     final int dPerWeek = isCustomBlock ? (customDaysPerWeek ?? workoutsPerWeek) : workoutsPerWeek;
 
     // 6) Insert instances; never abort the whole loop on lift seeding errors
+    final int numWorkouts = dPerWeek;
     int inserted = 0;
     for (int i = 0; i < distribution.length; i++) {
       final workout = distribution[i];
       final int week = (i ~/ dPerWeek) + 1;
+      final int slotIndex = i % numWorkouts;
 
       final int newWorkoutInstanceId = await db.insert(
         'workout_instances',
@@ -2007,6 +2085,7 @@ class DBService {
           'workoutName': workout['workoutName'],
           'blockName': blockName,
           'week': week,
+          'slotIndex': slotIndex,
           'startTime': null,
           'endTime': null,
           'completed': 0,


### PR DESCRIPTION
## Summary
- add `_hasColumn` helper and bump DB version
- migrate existing DBs to add `slotIndex` on workouts and `position`/`archived` on lift instances
- include `slotIndex` in `workout_instances` creation
- seed `slotIndex` when inserting workout instances for a block run
- add `_resizeEntriesForLiftInstanceTx` helper and invoke it when upserting `lift_instances`

## Testing
- `flutter format lib/services/db_service.dart` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4e90dcd6083238e5b70c58b7f4738