### PR TITLE
feat: add custom block edit loader

### DIFF
--- a/lib/screens/user_dashboard.dart
+++ b/lib/screens/user_dashboard.dart
@@ -86,7 +86,7 @@ class _UserDashboardState extends State<UserDashboard> {
   }
 
   Future<void> _editCustomBlock(int id) async {
-    final block = await DBService().getCustomBlock(id);
+    final block = await DBService().loadCustomBlockForEdit(id);
     if (block == null) return;
     await Navigator.push(
       context,

--- a/lib/services/db_service.dart
+++ b/lib/services/db_service.dart
@@ -1620,9 +1620,7 @@ class DBService {
     }
   }
 
-  // DEPRECATED: instance-only migration
-  Future<CustomBlock?> getCustomBlock(int id) async {
-    debugPrint('DEPRECATED: getCustomBlock called');
+  Future<CustomBlock?> loadCustomBlockForEdit(int id) async {
     final db = await database;
 
     // 1) Block row
@@ -1706,6 +1704,9 @@ class DBService {
       workouts: workouts,
     );
   }
+
+  @Deprecated('Use loadCustomBlockForEdit instead')
+  Future<CustomBlock?> getCustomBlock(int id) => loadCustomBlockForEdit(id);
 
   Future<int?> getCustomBlockIdForInstance(int blockInstanceId) async {
     final db = await database;
@@ -1838,7 +1839,7 @@ class DBService {
     final db = await database;
 
     // Load latest draft
-    final customBlock = await getCustomBlock(customBlockId);
+    final customBlock = await loadCustomBlockForEdit(customBlockId);
     if (customBlock == null || customBlock.workouts.isEmpty) return;
 
     await db.transaction((txn) async {
@@ -2355,7 +2356,7 @@ Future<void> updateWorkoutNameAcrossSlot(
   }
 
   Future<int> createBlockFromCustomBlockId(int customId, String userId) async {
-    final customBlock = await getCustomBlock(customId);
+    final customBlock = await loadCustomBlockForEdit(customId);
     if (customBlock == null) {
       throw Exception('Custom block not found: $customId');
     }

--- a/lib/widgets/block_grid_section.dart
+++ b/lib/widgets/block_grid_section.dart
@@ -108,7 +108,7 @@ class BlockGridSection extends StatelessWidget {
 
             if (action == 'edit') {
               // Load the custom block and open the wizard, passing the active instance if present.
-              final initial = await DBService().getCustomBlock(id);
+              final initial = await DBService().loadCustomBlockForEdit(id);
               if (initial != null && context.mounted) {
                 await Navigator.push(
                   context,


### PR DESCRIPTION
## Summary
- add `loadCustomBlockForEdit` to load custom block drafts directly from the database
- deprecate `getCustomBlock` and update callers to the new loader

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b78fbbcd0483238b6aae0ba22d9a4f