### PR TITLE
feat: make custom block loader instance-aware

### DIFF
--- a/lib/models/custom_block_models.dart
+++ b/lib/models/custom_block_models.dart
@@ -53,6 +53,19 @@ class CustomBlock {
   }
 }
 
+class CustomBlockForEdit extends CustomBlock {
+  CustomBlockForEdit({
+    required super.id,
+    required super.name,
+    required super.numWeeks,
+    required super.daysPerWeek,
+    required super.workouts,
+    super.scheduleType,
+    super.coverImagePath,
+    super.isDraft,
+  });
+}
+
 class WorkoutDraft {
   int id;
   int dayIndex;

--- a/lib/screens/user_dashboard.dart
+++ b/lib/screens/user_dashboard.dart
@@ -86,7 +86,8 @@ class _UserDashboardState extends State<UserDashboard> {
   }
 
   Future<void> _editCustomBlock(int id) async {
-    final block = await DBService().loadCustomBlockForEdit(id);
+    final block = await DBService()
+        .loadCustomBlockForEdit(customBlockId: id);
     if (block == null) return;
     await Navigator.push(
       context,

--- a/lib/widgets/block_grid_section.dart
+++ b/lib/widgets/block_grid_section.dart
@@ -108,7 +108,10 @@ class BlockGridSection extends StatelessWidget {
 
             if (action == 'edit') {
               // Load the custom block and open the wizard, passing the active instance if present.
-              final initial = await DBService().loadCustomBlockForEdit(id);
+              final initial = await DBService().loadCustomBlockForEdit(
+                customBlockId: id,
+                blockInstanceId: blockInstanceId,
+              );
               if (initial != null && context.mounted) {
                 await Navigator.push(
                   context,


### PR DESCRIPTION
## Summary
- introduce `CustomBlockForEdit` model and instance-aware `loadCustomBlockForEdit`
- support editing live block instances by loading workouts and lifts from instance tables when provided
- update dashboard and grid callers to pass block instance ids

## Testing
- `dart --version` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b78d13d1a88323b72903ea30c0a0f9