### PR TITLE
Fix custom block builder lift syncing

### DIFF
--- a/lib/screens/custom_block_wizard.dart
+++ b/lib/screens/custom_block_wizard.dart
@@ -186,7 +186,7 @@ class _CustomBlockWizardState extends State<CustomBlockWizard> {
     final file =
     File('${dir.path}/custom_block_${DateTime.now().millisecondsSinceEpoch}.jpg');
     await file.writeAsBytes(bytes);
-
+    if (!mounted) return;
     setState(() {
       _coverImageBytes = bytes;
       _coverImagePath = file.path;


### PR DESCRIPTION
## Summary
- show template lifts in builder without querying instances
- debounce builder edits and upsert lift metadata to DB
- guard setState on disposed widgets and fix liftName column
- keep lift metadata in builder state without Expando

## Testing
- `dart format lib/screens/workout_builder.dart lib/services/db_service.dart lib/screens/custom_block_wizard.dart` *(fails: command not found: dart)*
- `flutter test` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68b79c0a32588323a3086c215d1aa978