### PR TITLE
Fix wizard defaults and numeric score type

### DIFF
--- a/lib/screens/custom_block_wizard.dart
+++ b/lib/screens/custom_block_wizard.dart
@@ -96,6 +96,10 @@ class _CustomBlockWizardState extends State<CustomBlockWizard> {
       workouts = [];
       _nameCtrl.text = '';
       _currentStep = 0;
+      // ensure sane defaults for new blocks
+      _uniqueCount ??= 2;  // 1–7
+      daysPerWeek ??= 3;  // 1..?
+      numWeeks ??= 4;  // 3–6
     }
 
     // Keep blockName in sync with the field so step 0 can advance
@@ -628,7 +632,10 @@ class _CustomBlockWizardState extends State<CustomBlockWizard> {
                   .toList(),
               onChanged: (v) async {
                 if (v == null) return;
-                if (widget.blockInstanceId != null) {
+                final newCount = v;
+                final canApply = widget.blockInstanceId != null &&
+                    newCount != null && daysPerWeek != null && numWeeks != null;
+                if (canApply) {
                   final ok = await showConfirmDialog(
                     context,
                     title: 'Apply Shape Changes?',
@@ -639,12 +646,12 @@ class _CustomBlockWizardState extends State<CustomBlockWizard> {
                   await DBService().updateCustomBlockShape(
                     customBlockId: widget.customBlockId,
                     blockInstanceId: widget.blockInstanceId!,
-                    uniqueWorkoutCount: v,
+                    uniqueWorkoutCount: newCount,
                     workoutsPerWeek: daysPerWeek!,
                     totalWeeks: numWeeks!,
                   );
                 }
-                setState(() => _uniqueCount = v);
+                setState(() => _uniqueCount = newCount);
               },
             ),
             isActive: _currentStep >= 2,
@@ -659,7 +666,10 @@ class _CustomBlockWizardState extends State<CustomBlockWizard> {
                   .toList(),
               onChanged: (v) async {
                 if (v == null) return;
-                if (widget.blockInstanceId != null) {
+                final newDays = v;
+                final canApply = widget.blockInstanceId != null &&
+                    _uniqueCount != null && newDays != null && numWeeks != null;
+                if (canApply) {
                   final ok = await showConfirmDialog(
                     context,
                     title: 'Apply Shape Changes?',
@@ -671,11 +681,11 @@ class _CustomBlockWizardState extends State<CustomBlockWizard> {
                     customBlockId: widget.customBlockId,
                     blockInstanceId: widget.blockInstanceId!,
                     uniqueWorkoutCount: _uniqueCount!,
-                    workoutsPerWeek: v,
+                    workoutsPerWeek: newDays,
                     totalWeeks: numWeeks!,
                   );
                 }
-                setState(() => daysPerWeek = v);
+                setState(() => daysPerWeek = newDays);
               },
             ),
             isActive: _currentStep >= 3,
@@ -690,7 +700,10 @@ class _CustomBlockWizardState extends State<CustomBlockWizard> {
                   .toList(),
               onChanged: (v) async {
                 if (v == null) return;
-                if (widget.blockInstanceId != null) {
+                final newWeeks = v;
+                final canApply = widget.blockInstanceId != null &&
+                    _uniqueCount != null && daysPerWeek != null && newWeeks != null;
+                if (canApply) {
                   final ok = await showConfirmDialog(
                     context,
                     title: 'Apply Shape Changes?',
@@ -703,10 +716,10 @@ class _CustomBlockWizardState extends State<CustomBlockWizard> {
                     blockInstanceId: widget.blockInstanceId!,
                     uniqueWorkoutCount: _uniqueCount!,
                     workoutsPerWeek: daysPerWeek!,
-                    totalWeeks: v,
+                    totalWeeks: newWeeks,
                   );
                 }
-                setState(() => numWeeks = v);
+                setState(() => numWeeks = newWeeks);
               },
             ),
             isActive: _currentStep >= 4,

--- a/lib/screens/workout_builder.dart
+++ b/lib/screens/workout_builder.dart
@@ -85,7 +85,9 @@ class _WorkoutBuilderState extends State<WorkoutBuilder> {
           .map((l) => {
                 'liftId': null,
                 'repScheme': '${l.sets}x${l.repsPerSet}',
-                'scoreType': '',
+                'scoreType': l.isBodyweight
+                    ? SCORE_TYPE_BODYWEIGHT
+                    : SCORE_TYPE_MULTIPLIER,
                 'youtubeUrl': '',
                 'referenceLiftId': null,
                 'percentOfReference': null,
@@ -127,7 +129,8 @@ class _WorkoutBuilderState extends State<WorkoutBuilder> {
                 'liftId': (m['liftId'] as num?)?.toInt(),
                 'repScheme': (m['repScheme'] as String?) ??
                     '${m['sets'] ?? 0}x${m['repsPerSet'] ?? 0}',
-                'scoreType': m['scoreType']?.toString() ?? '',
+                'scoreType': (m['scoreType'] as num?)?.toInt() ??
+                    SCORE_TYPE_MULTIPLIER,
                 'youtubeUrl': m['youtubeUrl']?.toString() ?? '',
                 'referenceLiftId':
                     (m['referenceLiftId'] as num?)?.toInt(),
@@ -371,6 +374,9 @@ class _WorkoutBuilderState extends State<WorkoutBuilder> {
 
                               setLocalState(() => _isSaving = true);
                               try {
+                                final scoreType = isBodyweight
+                                    ? SCORE_TYPE_BODYWEIGHT
+                                    : SCORE_TYPE_MULTIPLIER;
                                 await DBService.instance.addLiftToCustomWorkout(
                                   customWorkoutId: widget.workout.id,
                                   liftCatalogId: selected!['catalogId'] as int,
@@ -380,15 +386,13 @@ class _WorkoutBuilderState extends State<WorkoutBuilder> {
                                   repsPerSet: reps,
                                   isBodyweight: isBodyweight ? 1 : 0,
                                   isDumbbell: isDumbbellLift ? 1 : 0,
-                                  scoreType:
-                                      isBodyweight ? 'bodyweight' : 'multiplier',
+                                  scoreType: scoreType,
                                 );
                                 widget.workout.lifts.add(newLift);
                                 _liftMeta.add({
                                   'liftId': selected!['catalogId'],
                                   'repScheme': repText,
-                                  'scoreType':
-                                      isBodyweight ? 'bodyweight' : 'multiplier',
+                                  'scoreType': scoreType,
                                 });
                                 _applyEditsSoon();
                                 setLocalState(() => _isSaving = false);
@@ -527,6 +531,9 @@ class _WorkoutBuilderState extends State<WorkoutBuilder> {
 
                               setLocalState(() => _isSaving = true);
 
+                              final scoreType = isBodyweight
+                                  ? SCORE_TYPE_BODYWEIGHT
+                                  : SCORE_TYPE_MULTIPLIER;
                               lift
                                 ..name = selected['name'] as String
                                 ..sets = sets
@@ -536,8 +543,7 @@ class _WorkoutBuilderState extends State<WorkoutBuilder> {
                               _liftMeta[index] = {
                                 'liftId': selected['catalogId'],
                                 'repScheme': repText,
-                                'scoreType':
-                                    isBodyweight ? 'bodyweight' : 'multiplier',
+                                'scoreType': scoreType,
                               };
                               _applyEditsSoon();
                               setLocalState(() => _isSaving = false);


### PR DESCRIPTION
## Summary
- default new custom blocks to 2 unique workouts, 3 days per week, and 4 weeks
- guard block shape updates until all stepper values are chosen
- use score type constants when adding or editing lifts in the workout builder

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8bed6afd88323ac7499bd2bf34e36