### PR TITLE
Hook score multiplier recalculation to rep scheme updates

### DIFF
--- a/lib/services/db_service.dart
+++ b/lib/services/db_service.dart
@@ -2356,6 +2356,14 @@ CREATE TABLE IF NOT EXISTS lift_aliases (
         // If schema lacks set index, skip pruning and rely on recalculation.
       }
     });
+
+    // Recompute score multiplier if the rep scheme changed for an active block.
+    if (blockInstanceId != null && (sets != null || repsPerSet != null)) {
+      await ScoreMultiplierService.computeAndApplyForCustomLift(
+        customLiftId: customLiftId,
+        blockInstanceId: blockInstanceId,
+      );
+    }
   }
 
   Future<void> syncBuilderEdits({


### PR DESCRIPTION
## Summary
- Document and enforce 7.5 lb progressive overload delta in score multiplier logic
- Determine initial weight using max logged set weight and recompute multiplier accordingly
- Recompute score multiplier when custom lift rep schemes change

## Testing
- `dart format lib/services/score_multiplier_service.dart lib/services/db_service.dart` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8cde210a08323962e6a433aa90e49