### PR TITLE
fix: normalize dumbbell flag mapping

### DIFF
--- a/lib/services/db_service.dart
+++ b/lib/services/db_service.dart
@@ -1352,7 +1352,7 @@ CREATE TABLE IF NOT EXISTS lift_aliases (
         CASE WHEN li.isBodyweight = 1 THEN $SCORE_TYPE_BODYWEIGHT ELSE $SCORE_TYPE_MULTIPLIER END AS scoreType,
         li.scoreMultiplier,
         li.isBodyweight,
-        li.isDumbbellLift AS isDumbbell,
+        li.isDumbbellLift,
         COALESCE(li.position,0) AS position
       FROM lift_instances li
       WHERE li.workoutInstanceId = ? AND COALESCE(li.archived,0) = 0


### PR DESCRIPTION
## Summary
- fetch custom lifts using `isDumbbellLift` column directly and let `_normalizeCustomLiftRow` map legacy names

## Testing
- `dart analyze lib/services/db_service.dart` *(command not found)*
- `flutter analyze lib/services/db_service.dart` *(command not found)*
- `apt-get update` *(403 forbidden: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b8d63c8bc4832392f02319439af010