### PR TITLE
chore: deprecate legacy shadow distribution functions

### DIFF
--- a/lib/services/db_service.dart
+++ b/lib/services/db_service.dart
@@ -3450,6 +3450,7 @@ Future<void> updateWorkoutNameAcrossSlot(
 // ──────────────────────────────────────────────
 // 🔄 GENERATE WORKOUT DISTRIBUTION BASED ON SCHEDULE TYPE
 // ──────────────────────────────────────────────
+  @Deprecated('Legacy shadow distribution') // TODO: Delete once custom scheduling is stable.
   Future<List<Map<String, dynamic>>> generateWorkoutDistribution(
       List<Map<String, dynamic>> workouts, String scheduleType) async {
     final int numWorkouts = workouts.length;

--- a/lib/web_tools/web_custom_block_service.dart
+++ b/lib/web_tools/web_custom_block_service.dart
@@ -290,6 +290,7 @@ class WebCustomBlockService {
 
   /// Public wrapper for [_generateWebWorkoutDistribution] so UI components
   /// can preview schedules without duplicating the logic.
+  @Deprecated('Legacy shadow distribution') // TODO: Delete once custom scheduling is stable.
   List<Map<String, dynamic>> previewDistribution(
     List<CustomWorkout> workouts,
     int weeks,
@@ -312,6 +313,7 @@ class WebCustomBlockService {
   /// Only the `standard` and `ab_alternate` schedule types are supported. The
   /// `weeks` parameter must be between 3 and 6 inclusive and `daysPerWeek` must
   /// be between 2 and 6 inclusive.
+  @Deprecated('Legacy shadow distribution') // TODO: Delete once custom scheduling is stable.
   List<Map<String, dynamic>> _generateWebWorkoutDistribution(
       List<CustomWorkout> workouts,
       int weeks,


### PR DESCRIPTION
## Summary
- mark legacy distribution utilities as deprecated for eventual removal

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b8d7278ab8832391d8fb3791fe7afb