### PR TITLE
Enforce catalog-only lifts in custom blocks

### DIFF
--- a/lib/services/db_service.dart
+++ b/lib/services/db_service.dart
@@ -2252,7 +2252,6 @@ CREATE TABLE IF NOT EXISTS lift_aliases (
   Future<int> addLiftToCustomWorkout({
     required int customWorkoutId,
     required int liftCatalogId,
-    required String name,
     required String repSchemeText,
     required int sets,
     required int repsPerSet,
@@ -2266,10 +2265,23 @@ CREATE TABLE IF NOT EXISTS lift_aliases (
       [customWorkoutId],
     );
     final position = (posRows.first['pos'] as num).toInt();
+
+    String? liftName;
+    final nameRows = await db.query(
+      'lift_catalog',
+      columns: ['name'],
+      where: 'catalogId = ?',
+      whereArgs: [liftCatalogId],
+      limit: 1,
+    );
+    if (nameRows.isNotEmpty) {
+      liftName = nameRows.first['name'] as String?;
+    }
+
     return await db.insert('custom_lifts', {
       'customWorkoutId': customWorkoutId,
       'liftCatalogId': liftCatalogId,
-      'name': name,
+      'name': liftName,
       'repSchemeText': repSchemeText,
       'sets': sets,
       'repsPerSet': repsPerSet,


### PR DESCRIPTION
## Summary
- filter out lifts lacking a catalog selection before syncing custom block edits
- require catalog selection when adding or editing lifts in custom blocks
- derive lift names from catalog in DB service to prevent custom entries

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403, unable to install Flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68b996f5a5fc8323bb191d6ca72883fe