### PR TITLE
Use catalogId field directly in lift catalog queries

### DIFF
--- a/lib/models/lift_catalog_models.dart
+++ b/lib/models/lift_catalog_models.dart
@@ -18,7 +18,7 @@ class LiftCatalogItem {
   });
 
   factory LiftCatalogItem.fromRow(Map<String, Object?> r) => LiftCatalogItem(
-    id: (r['catalogId'] ?? r['id']) as int,
+    id: r['catalogId'] as int,
     name: r['name'] as String,
     primaryGroup: (r['primaryGroup'] as String?) ?? '',
     equipment: r['equipment'] as String?,

--- a/lib/screens/workout_builder.dart
+++ b/lib/screens/workout_builder.dart
@@ -365,7 +365,7 @@ class _WorkoutBuilderState extends State<WorkoutBuilder> {
                       onPressed: isSaving || selected == null
                           ? null
                           : () async {
-                              final idVal = selected?['catalogId'] ?? selected?['id'];
+                              final idVal = selected?['catalogId'];
                               if (idVal == null) return;
                               final liftId = (idVal as num).toInt();
                               final name = selected?['name']?.toString() ?? '';

--- a/lib/services/lift_catalog_service.dart
+++ b/lib/services/lift_catalog_service.dart
@@ -71,7 +71,7 @@ class LiftCatalogService {
     if (dumbbellCapable == true)  where.add('isDumbbellCapable = 1');
 
     final sql = '''
-      SELECT id AS catalogId,
+      SELECT catalogId,
              name,
              primaryGroup,
              equipment,


### PR DESCRIPTION
## Summary
- Query catalog rows using `catalogId` column
- Remove fallbacks to legacy `id` field

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ea5cd9b88323bed89ddfd2b0b739