### PR TITLE
Ensure custom block exists before adding lifts

### DIFF
--- a/lib/services/db_service.dart
+++ b/lib/services/db_service.dart
@@ -2159,6 +2159,25 @@ CREATE TABLE IF NOT EXISTS lift_aliases (
   }) async {
     final db = await database;
 
+    // Ensure parent custom_blocks row exists to satisfy FK constraint.
+    // If the row already exists this insert is ignored.
+    final uid = FirebaseAuth.instance.currentUser?.uid ?? '';
+    final now = DateTime.now().millisecondsSinceEpoch;
+    await db.insert(
+      'custom_blocks',
+      {
+        'customBlockId': customBlockId,
+        'name': 'Untitled Block',
+        'uniqueWorkoutCount': 1,
+        'workoutsPerWeek': 1,
+        'totalWeeks': 1,
+        'ownerUid': uid,
+        'createdAt': now,
+        'updatedAt': now,
+      },
+      conflictAlgorithm: ConflictAlgorithm.ignore,
+    );
+
     // Resolve or create the custom_workouts row for this block/day
     int customWorkoutId;
     final cwRows = await db.query(


### PR DESCRIPTION
## Summary
- Prevent foreign key errors when adding lifts by ensuring the parent custom block row exists before inserting custom workouts

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba16e0697483239751468d541d6c8b