### PR TITLE
feat: add cover image path column

### DIFF
--- a/lib/services/db_service.dart
+++ b/lib/services/db_service.dart
@@ -39,7 +39,7 @@ class DBService {
   // 🔄 DATABASE INIT (v18, cleaned up)
   // ──────────────────────────────────────────────────────────
 
-  static const _dbVersion = 25;   // bump any time the schema changes
+  static const _dbVersion = 26;   // bump any time the schema changes
 
 
   Future<bool> _hasColumn(DatabaseExecutor db, String table, String col) async {
@@ -189,7 +189,9 @@ class DBService {
             status TEXT NOT NULL DEFAULT 'draft',
             createdAt INTEGER NOT NULL,
             updatedAt INTEGER NOT NULL,
-            isDraft INTEGER NOT NULL DEFAULT 1
+            isDraft INTEGER NOT NULL DEFAULT 1,
+            coverImagePath TEXT,
+            scheduleType TEXT NOT NULL DEFAULT 'standard'
           );
           ''');
           await db.execute('''
@@ -278,6 +280,17 @@ class DBService {
           ''');
           await db.execute('CREATE INDEX IF NOT EXISTS idx_lc_group ON lift_catalog(primaryGroup);');
           await db.execute('CREATE INDEX IF NOT EXISTS idx_la_alias ON lift_aliases(alias);');
+        }
+
+        if (oldV < 26) {
+          if (!await _hasColumn(db, 'custom_blocks', 'coverImagePath')) {
+            await db.execute(
+                "ALTER TABLE custom_blocks ADD COLUMN coverImagePath TEXT;");
+          }
+          if (!await _hasColumn(db, 'custom_blocks', 'scheduleType')) {
+            await db.execute(
+                "ALTER TABLE custom_blocks ADD COLUMN scheduleType TEXT NOT NULL DEFAULT 'standard';");
+          }
         }
       },
     );
@@ -464,7 +477,9 @@ CREATE TABLE IF NOT EXISTS custom_blocks (
   status TEXT NOT NULL DEFAULT 'draft',
   createdAt INTEGER NOT NULL,
   updatedAt INTEGER NOT NULL,
-  isDraft INTEGER NOT NULL DEFAULT 1
+  isDraft INTEGER NOT NULL DEFAULT 1,
+  coverImagePath TEXT,
+  scheduleType TEXT NOT NULL DEFAULT 'standard'
 );
 ''');
 


### PR DESCRIPTION
## Summary
- add coverImagePath column (and ensure scheduleType) to custom_blocks
- bump database version to 26 and migrate existing databases

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba2131ecfc8323961afb06b3e1ad10