### PR TITLE
Remove default hints for sets and reps fields

### DIFF
--- a/lib/screens/workout_builder.dart
+++ b/lib/screens/workout_builder.dart
@@ -273,8 +273,8 @@ class _WorkoutBuilderState extends State<WorkoutBuilder> {
   }
 
   void _showAddLiftSheet() {
-    final setsCtrl = TextEditingController(text: '3');
-    final repsCtrl = TextEditingController(text: '10');
+    final setsCtrl = TextEditingController();
+    final repsCtrl = TextEditingController();
     bool isBodyweight = false;
     bool isDumbbellLift = false;
     Map<String, Object?>? selected;


### PR DESCRIPTION
## Summary
- Avoid showing default hints for reps and sets when adding a lift in WorkoutBuilder

## Testing
- `flutter analyze` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ba2d408f888323b69489ec28e5ae55