### PR TITLE
Handle missing custom block ids in dashboard fetch

### DIFF
--- a/lib/screens/user_dashboard.dart
+++ b/lib/screens/user_dashboard.dart
@@ -72,7 +72,10 @@ class _UserDashboardState extends State<UserDashboard> {
     setState(() {
       customBlockNames =
           blocks.map((b) => b['name'].toString()).toList();
-      customBlockIds = blocks.map<int>((b) => b['id'] as int).toList();
+      customBlockIds = blocks
+          .map<int?>((b) => (b['id'] as int?) ?? (b['customBlockId'] as int?))
+          .whereType<int>()
+          .toList();
       customBlockImages = blocks
           .map<String>(
               (b) => b['coverImagePath']?.toString() ?? 'assets/logo25.jpg')


### PR DESCRIPTION
## Summary
- avoid casting null to int when building custom block ID list

## Testing
- `flutter analyze lib/screens/user_dashboard.dart` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68ba37d6553c832396320fdef01e3978