### PR TITLE
Fix ambiguous liftName column in custom lift query

### DIFF
--- a/lib/services/db_service.dart
+++ b/lib/services/db_service.dart
@@ -1234,7 +1234,7 @@ CREATE TABLE IF NOT EXISTS lift_aliases (
       SELECT
         li.liftInstanceId,
         li.liftId,
-        $liftNameCol AS name,
+        li.$liftNameCol AS name,
         li.sets,
         li.repsPerSet,
         li.scoreMultiplier,


### PR DESCRIPTION
## Summary
- Qualify `liftName` column with `lift_instances` alias to avoid SQL ambiguity when joining with `lifts`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba3e7d65e48323987e620d917ecc94