### PR TITLE
Ensure new lift IDs captured after DB insert

### DIFF
--- a/lib/screens/workout_builder.dart
+++ b/lib/screens/workout_builder.dart
@@ -396,7 +396,8 @@ class _WorkoutBuilderState extends State<WorkoutBuilder> {
                                     ? SCORE_TYPE_BODYWEIGHT
                                     : SCORE_TYPE_MULTIPLIER;
 
-                                await DBService.instance.addLiftToCustomWorkout(
+                                newLift.id = await DBService.instance
+                                    .addLiftToCustomWorkout(
                                   customBlockId: widget.customBlockId,
                                   dayIndex: widget.workout.dayIndex,
                                   workoutName: widget.workout.name,
@@ -412,7 +413,7 @@ class _WorkoutBuilderState extends State<WorkoutBuilder> {
                                       : 'multiplier', // or int if your API uses ints
                                 );
                                 debugPrint(
-                                    '[AddLift] DB insert OK (id=$liftId, "$name", $repText)');
+                                    '[AddLift] DB insert OK (id=${newLift.id}, "$name", $repText)');
 
                                 if (mounted) {
                                   setState(() {


### PR DESCRIPTION
## Summary
- Capture database insert ID for new lifts and assign to LiftDraft
- Preserve populated LiftDraft ID when updating state after save

## Testing
- `dart format lib/screens/workout_builder.dart lib/models/custom_block_models.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba46fdbb9483238ae8717578557f61