### PR TITLE
Handle closed connections in DB service

### DIFF
--- a/lib/services/db_service.dart
+++ b/lib/services/db_service.dart
@@ -30,7 +30,7 @@ class DBService {
   static Database? _database;
 
   Future<Database> get database async {
-    if (_database != null) return _database!;
+    if (_database != null && _database!.isOpen) return _database!;
     _database = await _initDatabase();
     return _database!;
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -67,6 +67,8 @@ dev_dependencies:
   flutter_launcher_icons: ^0.14.3
   flutter_lints: ^6.0.0
   flutter_native_splash: ^2.4.5
+  sqflite_common_ffi: ^2.3.2
+  test: ^1.24.0
 
 
 flutter_native_splash:

--- a/test/db_service_test.dart
+++ b/test/db_service_test.dart
@@ -1,0 +1,23 @@
+import 'package:test/test.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+import 'package:lift_league/services/db_service.dart';
+
+void main() {
+  setUpAll(() {
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+  });
+
+  test('reopens database if handle is closed', () async {
+    final service = DBService.instance;
+
+    final db1 = await service.database;
+    await db1.rawQuery('SELECT 1');
+
+    await db1.close();
+
+    final db2 = await service.database;
+    final result = await db2.rawQuery('SELECT 1');
+    expect(result, isNotEmpty);
+  });
+}


### PR DESCRIPTION
## Summary
- Reinitialize DB connection if the handle has been closed
- Add sqflite FFI and test packages for unit testing
- Test that closing and reopening the database still allows queries

## Testing
- `dart format lib/services/db_service.dart pubspec.yaml test/db_service_test.dart` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba49fa93fc83238c40474dfc6c0bb5