### PR TITLE
Ensure database reopens after dev reset

### DIFF
--- a/lib/services/db_service.dart
+++ b/lib/services/db_service.dart
@@ -671,7 +671,7 @@ CREATE TABLE IF NOT EXISTS lift_aliases (
     await deleteDatabase(path);
 
     // Reinitialize (will now trigger onCreate and create all tables)
-    await _initDatabase();
+    _database = await _initDatabase();
   }
 
   // ──────────────────────────────────────────────

--- a/test/db_service_test.dart
+++ b/test/db_service_test.dart
@@ -20,4 +20,12 @@ void main() {
     final result = await db2.rawQuery('SELECT 1');
     expect(result, isNotEmpty);
   });
+
+  test('resetDevDatabase reinitializes and allows queries', () async {
+    final service = DBService.instance;
+
+    await service.resetDevDatabase();
+
+    await expectLater(service.getBlockInstanceById(1), completes);
+  });
 }


### PR DESCRIPTION
## Summary
- Reinitialize `_database` when resetting the dev database so that a new connection is ready immediately
- Add regression test covering `resetDevDatabase` followed by `getBlockInstanceById`

## Testing
- `dart test` *(fails: command not found)*
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68ba4af0d31883239e4e14bfb09890eb