### PR TITLE
Lazily seed lift catalog within service

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -22,7 +22,6 @@ import 'package:lift_league/screens/custom_block_wizard.dart';
 import 'package:lift_league/screens/public_profile_screen.dart';
 import 'package:lift_league/services/notifications_service.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:lift_league/services/lift_catalog_service.dart';
 
 GoRouter createRouter() {
   return GoRouter(
@@ -147,7 +146,6 @@ void main() async {
     // 🔥 SETUP FCM PERMISSIONS AND LISTENERS
     await setupPushNotifications();
   }
-  await LiftCatalogService.instance.ensureSeeded();
 
   if (kIsWeb) {
     runApp(const POSSApp());


### PR DESCRIPTION
## Summary
- Add `_ensureInitialized` to `LiftCatalogService` and track initialization
- Invoke `_ensureInitialized` within `getGroups` and `query`
- Remove catalog seeding from `main` so initialization is handled in service

## Testing
- ❌ `dart test` *(command not found)*
- ❌ `flutter test` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68badf7be34c83238875eeb4aea50d71