### PR TITLE
refactor: decouple lift entries from instance id

### DIFF
--- a/lib/screens/workout_log.dart
+++ b/lib/screens/workout_log.dart
@@ -133,17 +133,24 @@ class WorkoutLogScreenState extends State<WorkoutLogScreen> with SingleTickerPro
           ? '$sets sets x $repsPerSet reps'
           : (lift['repScheme'] as String? ?? ''); // rare legacy fallback
 
+      final int scoreTypeInt =
+          (lift['scoreType'] as num?)?.toInt() ?? SCORE_TYPE_MULTIPLIER;
+      final String scoreType =
+          scoreTypeInt == SCORE_TYPE_BODYWEIGHT ? 'bodyweight' : 'multiplier';
+
       orderedLifts.add(
         Liftinfo(
           liftId: (lift['liftId'] as num?)?.toInt() ?? 0,
           workoutInstanceId: widget.workoutInstanceId,
           // built-ins return "name"; legacy paths returned "liftName"
-          liftName: (lift['liftName'] as String?) ?? (lift['name'] as String?) ?? 'Unknown',
+          liftName: (lift['liftName'] as String?) ??
+              (lift['name'] as String?) ??
+              'Unknown',
           repScheme: repScheme,
           numSets: sets,
           scoreMultiplier: ((lift['scoreMultiplier'] as num?) ?? 1.0).toDouble(),
           isDumbbellLift: ((lift['isDumbbellLift'] as num?) ?? 0).toInt() == 1,
-          scoreType: (lift['scoreType'] as String?) ?? 'multiplier',
+          scoreType: scoreType,
           youtubeUrl: lift['youtubeUrl'] as String? ?? '',
           description: lift['description'] as String? ?? '',
           referenceLiftId: (lift['referenceLiftId'] as num?)?.toInt(),

--- a/lib/services/db_service.dart
+++ b/lib/services/db_service.dart
@@ -39,7 +39,7 @@ class DBService {
   // 🔄 DATABASE INIT (v18, cleaned up)
   // ──────────────────────────────────────────────────────────
 
-  static const _dbVersion = 26;   // bump any time the schema changes
+  static const _dbVersion = 27;   // bump any time the schema changes
 
 
   Future<bool> _hasColumn(DatabaseExecutor db, String table, String col) async {
@@ -310,6 +310,31 @@ class DBService {
                 "ALTER TABLE custom_blocks ADD COLUMN scheduleType TEXT NOT NULL DEFAULT 'standard';");
           }
         }
+
+        if (oldV < 27) {
+          await db.execute('ALTER TABLE lift_entries RENAME TO lift_entries_old;');
+          await db.execute('''
+          CREATE TABLE lift_entries (
+            liftEntryId INTEGER PRIMARY KEY AUTOINCREMENT,
+            liftInstanceId INTEGER,
+            workoutInstanceId INTEGER,
+            liftId INTEGER,
+            setIndex INTEGER,
+            reps INTEGER,
+            weight REAL,
+            userId TEXT,
+            FOREIGN KEY (workoutInstanceId) REFERENCES workout_instances(workoutInstanceId) ON DELETE CASCADE
+          );
+          ''');
+          await db.execute('''
+          INSERT INTO lift_entries (liftInstanceId, workoutInstanceId, liftId, setIndex, reps, weight, userId)
+          SELECT liftInstanceId, workoutInstanceId, liftId, setIndex, reps, weight, userId
+          FROM lift_entries_old;
+          ''');
+          await db.execute('DROP TABLE lift_entries_old;');
+          await db.execute(
+              'CREATE UNIQUE INDEX IF NOT EXISTS idx_le_instance_set ON lift_entries(liftInstanceId, setIndex);');
+        }
       },
     );
   }
@@ -435,7 +460,8 @@ class DBService {
 
     await db.execute('''
       CREATE TABLE lift_entries (
-        liftInstanceId INTEGER PRIMARY KEY AUTOINCREMENT,
+        liftEntryId INTEGER PRIMARY KEY AUTOINCREMENT,
+        liftInstanceId INTEGER,
         workoutInstanceId INTEGER,
         liftId INTEGER,
         setIndex INTEGER,
@@ -445,6 +471,8 @@ class DBService {
         FOREIGN KEY (workoutInstanceId) REFERENCES workout_instances(workoutInstanceId) ON DELETE CASCADE
       )
     ''');
+    await db.execute(
+        'CREATE UNIQUE INDEX IF NOT EXISTS idx_le_instance_set ON lift_entries(liftInstanceId, setIndex);');
 
     await db.execute('''
       CREATE TABLE IF NOT EXISTS lift_totals (
@@ -1232,7 +1260,10 @@ CREATE TABLE IF NOT EXISTS lift_aliases (
         COALESCE(lw.isDumbbellLift,0) AS isDumbbellLift,
         COALESCE(lw.isBodyweight,0)   AS isBodyweight,
         COALESCE(lw.position, lw.liftWorkoutId) AS position,
-        l.scoreType           AS scoreType,
+        CASE l.scoreType
+          WHEN 'bodyweight' THEN $SCORE_TYPE_BODYWEIGHT
+          ELSE $SCORE_TYPE_MULTIPLIER
+        END AS scoreType,
         l.youtubeUrl          AS youtubeUrl,
         l.description         AS description,
         l.referenceLiftId     AS referenceLiftId,
@@ -1260,7 +1291,10 @@ CREATE TABLE IF NOT EXISTS lift_aliases (
         COALESCE(li.isDumbbellLift,0) AS isDumbbellLift,
         COALESCE(li.isBodyweight,0)   AS isBodyweight,
         COALESCE(li.position,0)       AS position,
-        l.scoreType           AS scoreType,
+        CASE l.scoreType
+          WHEN 'bodyweight' THEN $SCORE_TYPE_BODYWEIGHT
+          ELSE $SCORE_TYPE_MULTIPLIER
+        END AS scoreType,
         l.youtubeUrl          AS youtubeUrl,
         l.description         AS description,
         l.referenceLiftId     AS referenceLiftId,


### PR DESCRIPTION
## Summary
- split lift_entries identity from lift_instance linkage
- migrate existing data to use liftEntryId primary key with unique (liftInstanceId, setIndex)
- bump schema version to trigger migration
- return numeric scoreType from lift queries to prevent type errors
- map numeric score types to legacy strings when loading workout logs

## Testing
- `dart format lib/screens/workout_log.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68baf49a30008323a155e61ba037339b