### PR TITLE
refactor: decouple lift entries from instance id

### DIFF
--- a/lib/screens/workout_log.dart
+++ b/lib/screens/workout_log.dart
@@ -133,17 +133,24 @@ class WorkoutLogScreenState extends State<WorkoutLogScreen> with SingleTickerPro
           ? '$sets sets x $repsPerSet reps'
           : (lift['repScheme'] as String? ?? ''); // rare legacy fallback
 
+      final int scoreTypeInt =
+          (lift['scoreType'] as num?)?.toInt() ?? SCORE_TYPE_MULTIPLIER;
+      final String scoreType =
+          scoreTypeInt == SCORE_TYPE_BODYWEIGHT ? 'bodyweight' : 'multiplier';
+
       orderedLifts.add(
         Liftinfo(
           liftId: (lift['liftId'] as num?)?.toInt() ?? 0,
           workoutInstanceId: widget.workoutInstanceId,
           // built-ins return "name"; legacy paths returned "liftName"
-          liftName: (lift['liftName'] as String?) ?? (lift['name'] as String?) ?? 'Unknown',
+          liftName: (lift['liftName'] as String?) ??
+              (lift['name'] as String?) ??
+              'Unknown',
           repScheme: repScheme,
           numSets: sets,
           scoreMultiplier: ((lift['scoreMultiplier'] as num?) ?? 1.0).toDouble(),
           isDumbbellLift: ((lift['isDumbbellLift'] as num?) ?? 0).toInt() == 1,
-          scoreType: (lift['scoreType'] as String?) ?? 'multiplier',
+          scoreType: scoreType,
           youtubeUrl: lift['youtubeUrl'] as String? ?? '',
           description: lift['description'] as String? ?? '',
           referenceLiftId: (lift['referenceLiftId'] as num?)?.toInt(),


### PR DESCRIPTION
## Summary
- split lift_entries identity from lift_instance linkage
- migrate existing data to use liftEntryId primary key with unique (liftInstanceId, setIndex)
- ensure resizing adds only missing set rows to avoid unique constraint failures
- bump schema version to trigger migration
- return numeric scoreType from lift queries to prevent type errors
- map numeric score types to legacy strings when loading workout logs

## Testing
- `dart format lib/services/db_service.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68baf49a30008323a155e61ba037339b