### PR TITLE
Track custom block instances by ID

### DIFF
--- a/lib/screens/custom_block_wizard.dart
+++ b/lib/screens/custom_block_wizard.dart
@@ -245,6 +245,12 @@ class _CustomBlockWizardState extends State<CustomBlockWizard> {
   }
 
   Future<void> _openWorkoutEditorFullscreen() async {
+    int? activeInstanceId = widget.blockInstanceId;
+    if (activeInstanceId == null) {
+      activeInstanceId =
+          await DBService().getBlockInstanceIdByCustomBlockId(widget.customBlockId);
+    }
+
     await showGeneralDialog(
       context: context,
       barrierDismissible: false,
@@ -314,7 +320,7 @@ class _CustomBlockWizardState extends State<CustomBlockWizard> {
                             return;
                           }
 
-                          if (widget.blockInstanceId != null) {
+                          if (activeInstanceId != null) {
                             final ok = await showConfirmDialog(
                               context,
                               title: 'Build Block?',
@@ -345,7 +351,7 @@ class _CustomBlockWizardState extends State<CustomBlockWizard> {
                         },
                         showDumbbellOption: true,
                         customBlockId: widget.customBlockId,
-                        activeBlockInstanceId: widget.blockInstanceId,
+                        activeBlockInstanceId: activeInstanceId,
                         onPreviewSchedule: _previewSchedule,
                       ),
               ),

--- a/lib/services/db_service.dart
+++ b/lib/services/db_service.dart
@@ -735,7 +735,7 @@ CREATE TABLE IF NOT EXISTS lift_aliases (
     final db = await database;
 
     return await db.rawQuery('''
-    SELECT DISTINCT blockInstanceId, blockName
+    SELECT DISTINCT blockInstanceId, blockName, customBlockId
     FROM block_instances
     WHERE userId = ?
     ORDER BY blockInstanceId ASC
@@ -861,6 +861,15 @@ CREATE TABLE IF NOT EXISTS lift_aliases (
       whereArgs: [blockName, userId],
       orderBy: 'blockInstanceId ASC',
     );
+  }
+
+  Future<int?> getBlockInstanceIdByCustomBlockId(int customBlockId) async {
+    final db = await database;
+    final rows = await db.rawQuery(
+        'SELECT blockInstanceId FROM block_instances WHERE customBlockId = ? LIMIT 1',
+        [customBlockId]);
+    if (rows.isEmpty) return null;
+    return (rows.first['blockInstanceId'] as num?)?.toInt();
   }
 
   // ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Include `customBlockId` in block instance queries and add lookup helper
- Track custom block instances by ID on the dashboard
- Resolve and use block instance IDs in CustomBlockWizard's workout editor

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb0b3c72148323a0ee1eaca33f0fe5