### PR TITLE
Fix dayIndex vs slotIndex mismatch

### DIFF
--- a/lib/screens/workout_builder.dart
+++ b/lib/screens/workout_builder.dart
@@ -126,10 +126,15 @@ class _WorkoutBuilderState extends State<WorkoutBuilder> {
         await DBService().getLiftsForWorkoutInstance(widget.workout.id);
     if (!mounted) return;
 
+    // dayIndex in the DB is 1-based; convert to 0-based for the UI
+    final int? dbDayIndex = inst['dayIndex'] as int?;
+    final int adjustedDayIndex =
+        dbDayIndex != null ? dbDayIndex - 1 : widget.workout.dayIndex;
+
     setState(() {
       widget.workout
         ..name = (inst['workoutName'] as String? ?? widget.workout.name)
-        ..dayIndex = (inst['dayIndex'] as int? ?? widget.workout.dayIndex)
+        ..dayIndex = adjustedDayIndex
         ..isPersisted = true;
       widget.workout.lifts
         ..clear()

--- a/lib/services/db_service.dart
+++ b/lib/services/db_service.dart
@@ -2423,8 +2423,9 @@ CREATE TABLE IF NOT EXISTS lift_aliases (
       final baseRows = await txn.query(
         'workout_instances',
         columns: ['workoutInstanceId'],
+        // slotIndex is 1-based while dayIndex is 0-based in the UI
         where: 'blockInstanceId = ? AND slotIndex = ?',
-        whereArgs: [blockInstanceId, dayIndex],
+        whereArgs: [blockInstanceId, dayIndex + 1],
         limit: 1,
       );
       if (baseRows.isEmpty) return;


### PR DESCRIPTION
## Summary
- align active workout lookup with 1-based slot indices
- convert database dayIndex to 0-based when loading workouts in the builder

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb574111f0832398d5366477017bf4