### PR TITLE
Normalize day indices for builder edits

### DIFF
--- a/lib/screens/custom_block_wizard.dart
+++ b/lib/screens/custom_block_wizard.dart
@@ -79,6 +79,11 @@ class _CustomBlockWizardState extends State<CustomBlockWizard> {
                 ))
             .toList();
 
+        // Normalize day indices to zero-based, sequential values
+        for (int i = 0; i < workouts.length; i++) {
+          workouts[i].dayIndex = i;
+        }
+
         _coverImagePath = block.coverImagePath;
         if (_coverImagePath != null && File(_coverImagePath!).existsSync()) {
           _coverImageBytes = File(_coverImagePath!).readAsBytesSync();

--- a/lib/services/db_service.dart
+++ b/lib/services/db_service.dart
@@ -2358,12 +2358,15 @@ CREATE TABLE IF NOT EXISTS lift_aliases (
   }) async {
     final db = await database;
 
+    // dayIndex is 0-based in the UI but positions are 1-based in the DB
+    final schemaDayIndex = dayIndex + 1;
+
     // Determine the template workout we're editing
     final cwRows = await db.query(
       'custom_workouts',
       columns: ['id'],
       where: 'customBlockId = ? AND position = ?',
-      whereArgs: [customBlockId, dayIndex],
+      whereArgs: [customBlockId, schemaDayIndex],
       limit: 1,
     );
     if (cwRows.isEmpty) return;
@@ -2425,7 +2428,7 @@ CREATE TABLE IF NOT EXISTS lift_aliases (
         columns: ['workoutInstanceId'],
         // slotIndex is 1-based while dayIndex is 0-based in the UI
         where: 'blockInstanceId = ? AND slotIndex = ?',
-        whereArgs: [blockInstanceId, dayIndex + 1],
+        whereArgs: [blockInstanceId, schemaDayIndex],
         limit: 1,
       );
       if (baseRows.isEmpty) return;

--- a/lib/web_tools/POSS_block_builder.dart
+++ b/lib/web_tools/POSS_block_builder.dart
@@ -89,6 +89,10 @@ class _POSSBlockBuilderState extends State<POSSBlockBuilder> {
             ),
           )
           .toList();
+      // Normalize day indices to zero-based, sequential values
+      for (int i = 0; i < _workouts.length; i++) {
+        _workouts[i].dayIndex = i;
+      }
       _uniqueCount = _workouts.length;
       _coverImageUrl = block.coverImagePath;
       // Editing an existing block jumps directly to the workout builder step.


### PR DESCRIPTION
## Summary
- convert `dayIndex` to schema indexing in `syncBuilderEdits`
- normalize workout drafts to zero-based indices when initializing edits

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb5a0b5248832393eec18a5463c860