### PR TITLE
Normalize custom lifts multiplier fields

### DIFF
--- a/lib/screens/workout_builder.dart
+++ b/lib/screens/workout_builder.dart
@@ -416,6 +416,8 @@ class _WorkoutBuilderState extends State<WorkoutBuilder> {
                                   scoreType: isBodyweight
                                       ? 'bodyweight'
                                       : 'multiplier', // or int if your API uses ints
+                                  multiplier:
+                                      isBodyweight ? null : newLift.multiplier,
                                 );
                                 debugPrint(
                                     '[AddLift] DB insert OK (id=${newLift.id}, "$name", $repText)');


### PR DESCRIPTION
## Summary
- align the custom_lifts table schema with db.md by persisting baseMultiplier/logUnilaterally alongside legacy columns
- normalize custom lift inserts/updates/reads to favor the new columns while keeping backwards-compatible fallbacks
- allow addLiftToCustomWorkout to accept an optional multiplier so UI additions can persist normalized values

## Testing
- flutter analyze *(fails: flutter command not available in container)*
- dart analyze *(fails: dart command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e5c1abed2083239fd22780a11b64d3