### PR TITLE
Normalize custom lifts multiplier fields

### DIFF
--- a/lib/services/score_multiplier_service.dart
+++ b/lib/services/score_multiplier_service.dart
@@ -88,7 +88,10 @@ class ScoreMultiplierService {
 
       await txn.update(
         'custom_lifts',
-        {'scoreMultiplier': multiplier},
+        {
+          'scoreMultiplier': multiplier,
+          'baseMultiplier': multiplier,
+        },
         where: 'id = ?',
         whereArgs: [customLiftId],
       );


### PR DESCRIPTION
## Summary
- align the custom_lifts table schema with db.md by persisting baseMultiplier/logUnilaterally alongside legacy columns
- normalize custom lift inserts/updates/reads to favor the new columns while keeping backwards-compatible fallbacks
- allow addLiftToCustomWorkout to accept an optional multiplier so UI additions can persist normalized values
- keep baseMultiplier in sync with scoreMultiplier during recomputation so loaders surface refreshed values

## Testing
- flutter analyze *(fails: flutter command not available in container)*
- dart analyze *(fails: dart command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e5d592ca888323b199d81f2cf3d89a